### PR TITLE
Added fields added migration and unit tests

### DIFF
--- a/.swiftlint.yaml
+++ b/.swiftlint.yaml
@@ -1,3 +1,4 @@
 disabled_rules:
   - type_name
   - private_over_fileprivate
+  - switch_case_alignment

--- a/Sources/CommonVeinMacroLogic/ModelMacro.swift
+++ b/Sources/CommonVeinMacroLogic/ModelMacro.swift
@@ -87,7 +87,7 @@ public struct Model {
         
         let eagerVarInit = eagerFields.map { key, value in
             let value = value.drop(while: { $0 == " " || $0 == ":" })
-            return "self.\(key) = try! \(value).init(fromPersistent: \(value).PersistentRepresentation.decode(sqliteValue: fields[\"\(key)\"]!))\(value.hasSuffix("?") ? "": "!")"
+            return "self.\(key) = try! \(value).init(fromPersistent: \(value).PersistentRepresentation.decode(sqliteValue: fields[\"\(key)\"]!))!"
         }.joined(separator: "\n        ")
         
         var fieldInformation = lazyFields.map { key, value in

--- a/Sources/Vein/ManagedObjectContext/Values/DTOs.swift
+++ b/Sources/Vein/ManagedObjectContext/Values/DTOs.swift
@@ -47,7 +47,10 @@ extension FieldInformation {
                     case .real: Expression<Double?>(key)
                     case .text: Expression<String?>(key)
                     case .blob: Expression<Data?>(key)
-                    default: fatalError()
+                    default:
+                        fatalError(
+                            "Unexpectedly found null. Check SQLiteTypeName.notNull() for logic errors"
+                        )
                 }
             case false:
                 switch typeName {
@@ -55,7 +58,10 @@ extension FieldInformation {
                     case .real: Expression<Double>(key)
                     case .text: Expression<String>(key)
                     case .blob: Expression<Data>(key)
-                    default: fatalError()
+                    default:
+                        fatalError(
+                            "Unexpectedly found null. Check SQLiteTypeName.notNull() for logic errors"
+                        )
                 }
         }
     }
@@ -79,7 +85,9 @@ extension FieldInformation {
                     Table(schema).addColumn(Expression<Data?>(key))
                 )
             case .null:
-                fatalError()
+                fatalError(
+                    "Unexpectedly found null. Check SQLiteTypeName.notNull() for logic errors"
+                )
         }
     }
 }

--- a/Sources/Vein/ManagedObjectContext/Values/DTOs.swift
+++ b/Sources/Vein/ManagedObjectContext/Values/DTOs.swift
@@ -42,7 +42,7 @@ extension FieldInformation {
     package var expressible: Expressible {
         return switch typeName.isNull {
             case true:
-                switch typeName {
+                switch SQLiteTypeName.notNull(typeName) {
                     case .integer: Expression<Int64?>(key)
                     case .real: Expression<Double?>(key)
                     case .text: Expression<String?>(key)
@@ -57,6 +57,29 @@ extension FieldInformation {
                     case .blob: Expression<Data>(key)
                     default: fatalError()
                 }
+        }
+    }
+    
+    package func addRetroactively(to schema: String, on context: ManagedObjectContext) throws {
+        switch SQLiteTypeName.notNull(typeName) {
+            case .integer:
+                try context.run(
+                    Table(schema).addColumn(Expression<Int64?>(key))
+                )
+            case .real:
+                try context.run(
+                    Table(schema).addColumn(Expression<Double?>(key))
+                )
+            case .text:
+                try context.run(
+                    Table(schema).addColumn(Expression<String?>(key))
+                )
+            case .blob:
+                try context.run(
+                    Table(schema).addColumn(Expression<Data?>(key))
+                )
+            case .null:
+                fatalError()
         }
     }
 }

--- a/Sources/Vein/ManagedObjectContext/Values/ManagedObjectContextError.swift
+++ b/Sources/Vein/ManagedObjectContext/Values/ManagedObjectContextError.swift
@@ -20,6 +20,8 @@ public enum ManagedObjectContextError: Error {
     case baseNotOlderThanDestination(any PersistentModel.Type, any PersistentModel.Type)
     case fieldMismatch(any PersistentModel.Type, any PersistentModel.Type)
     case notInsideMigration(String)
+    case destinationMustHaveOnlyAddedFields(any PersistentModel.Type, any PersistentModel.Type)
+    case automaticMigrationRequiresOnlyOptionalFieldsAdded(any PersistentModel.Type, any PersistentModel.Type)
     case other(message: String)
 }
 
@@ -58,6 +60,18 @@ extension ManagedObjectContextError: LocalizedError {
                 return "Fields of \(origin.schema) don't match fields of \(destination.schema)"
             case .notInsideMigration(let message):
                 return "Function is only available during a migration: \(message)"
+            case .destinationMustHaveOnlyAddedFields(let origin, let destination):
+                return
+                    """
+                    PersistentModel/fieldsAddedMigration requires only adding Fields. \
+                    Migration between \(origin.schema) and \(destination.schema)
+                    """
+            case .automaticMigrationRequiresOnlyOptionalFieldsAdded(let origin, let destination):
+                return
+                    """
+                    PersistentModel/fieldsAddedMigration requires added fields to have nullable SQLiteValue. \
+                    Migration between \(origin.schema) and \(destination.schema)
+                    """
             case .other(let message):
                 return "Unexpected: \(message)"
         }
@@ -97,6 +111,10 @@ extension ManagedObjectContextError: LocalizedError {
                 return "PersistentModel/unchangedMigration requires fields of origin and destination to have unchanged underlying types and names"
             case .notInsideMigration:
                 return "Certain functions are only available during migrations to ensure stability"
+            case .destinationMustHaveOnlyAddedFields:
+                return "Destination model doesn't have the same fields as the origin model plus new ones"
+            case .automaticMigrationRequiresOnlyOptionalFieldsAdded:
+                return "New schema adds non-optional Fields."
             case .other:
                 return nil
         }
@@ -130,6 +148,14 @@ extension ManagedObjectContextError: LocalizedError {
                 return "Make sure the fields of both versions haven't changed or migrate manually"
             case .notInsideMigration:
                 return "Make sure to only call the function during an active migration"
+            case .destinationMustHaveOnlyAddedFields:
+                return
+                    """
+                    Use PersistentModel/unchangedMigration if the Field names and \
+                    underlying SQLite Values didn't change or migrate manually.
+                    """
+            case .automaticMigrationRequiresOnlyOptionalFieldsAdded:
+                return "Only add Fields with nullable SQLiteValue or migrate manually."
             case .other:
                 return nil
         }

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -86,7 +86,7 @@ extension PersistentModel {
     ) throws {
         guard context.isInActiveMigration else {
             throw ManagedObjectContextError
-                .notInsideMigration("PersistentModel/unchangedMigration")
+                .notInsideMigration("PersistentModel/fieldsAddedMigration")
         }
         
         guard version < newModel.version else {

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -65,6 +65,7 @@ extension PersistentModel {
         }
         
         try context.renameSchema(schema, to: newModel.schema)
+        try context.registerMigration(schema: newModel.schema, version: newModel.version)
     }
     
     @MainActor
@@ -124,11 +125,12 @@ extension PersistentModel {
             for information in toAddInformation {
                 try information.addRetroactively(to: newModel.schema, on: context)
             }
+            try context.registerMigration(schema: newModel.schema, version: newModel.version)
         } catch let error as SQLite.Result {
             let parsed = error.parse()
             switch parsed {
-                // Returning, because schema will be created on first Model insert
-                // Therefore noSuchTable is acceptable here
+                    // Returning, because schema will be created on first Model insert
+                    // Therefore noSuchTable is acceptable here
                 case .noSuchTable: return
                 default: throw parsed
             }

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -78,6 +78,62 @@ extension PersistentModel {
         
         try context.deleteTable(schema)
     }
+    
+    @MainActor
+    public static func fieldsAddedMigration(
+        to newModel: any PersistentModel.Type,
+        on context: ManagedObjectContext
+    ) throws {
+        guard context.isInActiveMigration else {
+            throw ManagedObjectContextError
+                .notInsideMigration("PersistentModel/unchangedMigration")
+        }
+        
+        guard version < newModel.version else {
+            throw ManagedObjectContextError
+                .baseNotOlderThanDestination(Self.self, newModel)
+        }
+        
+        let oldInformationSet = Set(Self._fieldInformation)
+        let newInformationSet = Set(newModel._fieldInformation)
+        
+        let toAddInformation = newInformationSet.subtracting(oldInformationSet)
+        
+        guard
+            Self._fieldInformation.count < newModel._fieldInformation.count,
+            toAddInformation.count
+            ==
+            newInformationSet.count - oldInformationSet.count
+        else {
+            throw ManagedObjectContextError
+                .destinationMustHaveOnlyAddedFields(Self.self, newModel)
+        }
+        
+        guard
+            !toAddInformation.contains(where: {
+                !$0.typeName.isNull
+            })
+        else {
+            throw ManagedObjectContextError
+                .automaticMigrationRequiresOnlyOptionalFieldsAdded(Self.self, newModel)
+        }
+        
+        do {
+            try context.renameSchema(schema, to: newModel.schema)
+            
+            for information in toAddInformation {
+                try information.addRetroactively(to: newModel.schema, on: context)
+            }
+        } catch let error as SQLite.Result {
+            let parsed = error.parse()
+            switch parsed {
+                // Returning, because schema will be created on first Model insert
+                // Therefore noSuchTable is acceptable here
+                case .noSuchTable: return
+                default: throw parsed
+            }
+        }
+    }
 }
 
 struct AnyPersistentModelType: Hashable {

--- a/Tests/VeinTests/Migrations/FieldsAdded.swift
+++ b/Tests/VeinTests/Migrations/FieldsAdded.swift
@@ -417,6 +417,8 @@ fileprivate enum SimpleMigration: SchemaMigrationPlan {
                 let new = SimpleSchemaV0_0_4.Test(
                     addedAt: Date(timeIntervalSince1970: Double(model.date))
                 )
+                new.additionalField = model.additionalField
+                
                 try context.delete(model)
                 try context.insert(new)
             }

--- a/Tests/VeinTests/Migrations/FieldsAdded.swift
+++ b/Tests/VeinTests/Migrations/FieldsAdded.swift
@@ -6,92 +6,48 @@ import Logging
 
 extension MigrationTests {
     @Test
-    func simpleMigration() throws {
-        let dbPath = try prepareContainerLocation(name: "simpleMigration")
+    func fieldsAddedMigration() throws {
+        let dbPath = try prepareContainerLocation(name: "fieldAddedMigration")
         
         logger.info(
-            "Simple migration test started with db location: \(dbPath)"
+            "Field added migration test started with db location: \(dbPath)"
         )
         
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
+        let container = try ModelContainer(models: SimpleSchemaV0_0_3.models, migration: SimpleMigration.self, at: dbPath)
         
-        let test = SimpleSchemaV0_0_1.Test(date: Date())
-        let unused = SimpleSchemaV0_0_1.Unused(content: "whoppa")
+        let test = SimpleSchemaV0_0_3.AddingFieldsModel(value: "")
         
         try container.context.insert(test)
-        try container.context.insert(unused)
         
         // Check both tables exist under the expected name
         let storedSchemas = try container.context.getAllStoredSchemas()
         #expect(
             storedSchemas.sorted() == [
-                SimpleSchemaV0_0_1.Test.schema,
-                SimpleSchemaV0_0_1.Unused.schema
+                SimpleSchemaV0_0_3.AddingFieldsModel.schema
             ].sorted()
         )
         
         // Create new container & trigger migration
-        let newContainer = try ModelContainer(models: SimpleSchemaV0_0_2.models, migration: SimpleMigrationSuccess.self, at: dbPath)
+        let newContainer = try ModelContainer(models: SimpleSchemaV0_0_4.models, migration: SimpleMigration.self, at: dbPath)
         try newContainer.migrate()
         
         // Check new model was migrated correctly
-        let first = try newContainer.context.fetchAll(SimpleSchemaV0_0_2.Test._PredicateHelper()._builder()).first
+        let first = try newContainer.context.fetchAll(
+            SimpleSchemaV0_0_4.AddingFieldsModel._PredicateHelper()._builder()
+        ).first
         
-        #expect(first?.date == test.date.ISO8601Format(Date.sqliteFormatStyle))
+        #expect(first?.newValue == nil)
+        #expect(first?.value == test.value)
         
         // Check if tables got updated/deleted like expected
         let newStoredSchemas = try newContainer.context.getAllStoredSchemas()
-        #expect(newStoredSchemas == [SimpleSchemaV0_0_2.Test.schema])
+        #expect(newStoredSchemas == [SimpleSchemaV0_0_4.AddingFieldsModel.schema])
     }
     
     @Test
-    func unchangedFailsOutsideMigration() throws {
-        let dbPath = try prepareContainerLocation(name: "tableDeletion")
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
-        
-        
-        do {
-            try SimpleSchemaV0_0_1.Test
-                .unchangedMigration(
-                    to: SimpleSchemaV0_0_2.Test.self,
-                    on: container.context
-                )
-        } catch let error as ManagedObjectContextError {
-            if case let .notInsideMigration(function) = error {
-                #expect(function == "PersistentModel/unchangedMigration")
-                return
-            }
-            Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
-        } catch {
-            Issue.record("Thrown error does not match expectations: \(error)")
-        }
-        Issue.record("Unexpectedly no error was thrown")
-    }
-    
-    @Test
-    func deleteFailsOutsideMigration() throws {
-        let dbPath = try prepareContainerLocation(name: "tableDeletion")
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
-
-        do {
-            try SimpleSchemaV0_0_1.Test
-                .deleteMigration(on: container.context)
-        } catch let error as ManagedObjectContextError {
-            if case let .notInsideMigration(function) = error {
-                #expect(function == "PersistentModel/deleteMigration")
-                return
-            }
-            Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
-        } catch {
-            Issue.record("Thrown error does not match expectations: \(error)")
-        }
-        Issue.record("Unexpectedly no error was thrown")
-    }
-    
-    @Test
-    func versionOrderThrowsOnUnchangedMigration() throws {
+    func versionOrderThrowsOnFieldsAddedMigration() throws {
         let dbPath = try prepareContainerLocation(name: "errorTests")
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
+        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigration.self, at: dbPath)
         
         // Entering migration manually
         // This is an internal function and not publicly exposed
@@ -99,7 +55,7 @@ extension MigrationTests {
         
         do {
             try SimpleSchemaV0_0_2.Test
-                .unchangedMigration(
+                .fieldsAddedMigration(
                     to: SimpleSchemaV0_0_1.Test.self,
                     on: container.context
                 )
@@ -117,25 +73,25 @@ extension MigrationTests {
             Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
             return
         } catch {
-            Issue.record("Thrown error does not match expectations: \(error)")
+            Issue.record("Thrown error does not match expectations: \(error.localizedDescription)")
             return
         }
+        
         Issue.record("Unexpectedly no error was thrown")
     }
     
     @Test
-    func equalVersionThrowsOnUnchangedMigration() throws {
+    func equalVersionThrowsOnFieldsAddedMigration() throws {
         let dbPath = try prepareContainerLocation(name: "errorTests")
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
+        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigration.self, at: dbPath)
         
         // Entering migration manually
         // This is an internal function and not publicly exposed
         container.context.isInActiveMigration = true
         
-        // Testing PersistentModel/unchangedMigration
         do {
             try SimpleSchemaV0_0_2.Test
-                .unchangedMigration(
+                .fieldsAddedMigration(
                     to: SimpleSchemaV0_0_2.Test.self,
                     on: container.context
                 )
@@ -153,77 +109,77 @@ extension MigrationTests {
             Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
             return
         } catch {
-            Issue.record("Thrown error does not match expectations: \(error)")
+            Issue.record("Thrown error does not match expectations: \(error.localizedDescription)")
             return
         }
         Issue.record("Unexpectedly no error was thrown")
     }
     
     @Test
-    func unchangedMigrationFieldMismatchOnSQLiteTypeChange() throws {
+    func destinationMustHaveOnlyAddedFieldsOnFieldsAddedMigration() throws {
         let dbPath = try prepareContainerLocation(name: "errorTests")
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
+        let container = try ModelContainer(models: SimpleSchemaV0_0_3.models, migration: SimpleMigration.self, at: dbPath)
         
         // Entering migration manually
         // This is an internal function and not publicly exposed
         container.context.isInActiveMigration = true
         
         do {
-            try SimpleSchemaV0_0_1.Test
-                .unchangedMigration(
-                    to: SimpleSchemaV0_0_3.Test.self,
+            try SimpleSchemaV0_0_3.AddingFieldsModel
+                .fieldsAddedMigration(
+                    to: SimpleSchemaV0_0_6.AddingFieldsModel.self,
                     on: container.context
                 )
         } catch let error as ManagedObjectContextError {
             if
-                case let .fieldMismatch(
+                case let .destinationMustHaveOnlyAddedFields(
                     base,
                     destination
                 ) = error
             {
-                #expect(base.schema == SimpleSchemaV0_0_1.Test.schema)
-                #expect(destination.schema == SimpleSchemaV0_0_3.Test.schema)
+                #expect(base.schema == SimpleSchemaV0_0_3.AddingFieldsModel.schema)
+                #expect(destination.schema == SimpleSchemaV0_0_6.AddingFieldsModel.schema)
                 return
             }
             Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
             return
         } catch {
-            Issue.record("Thrown error does not match expectations: \(error)")
+            Issue.record("Thrown error does not match expectations: \(error.localizedDescription)")
             return
         }
         Issue.record("Unexpectedly no error was thrown")
     }
     
     @Test
-    func unchangedMigrationFieldMismatchOnNameChange() throws {
+    func requiresOnlyOptionalFieldsAddedOnFieldsAddedMigration() throws {
         let dbPath = try prepareContainerLocation(name: "errorTests")
-        let container = try ModelContainer(models: SimpleSchemaV0_0_1.models, migration: SimpleMigrationSuccess.self, at: dbPath)
+        let container = try ModelContainer(models: SimpleSchemaV0_0_3.models, migration: SimpleMigration.self, at: dbPath)
         
         // Entering migration manually
         // This is an internal function and not publicly exposed
         container.context.isInActiveMigration = true
         
         do {
-            try SimpleSchemaV0_0_1.Test
-                .unchangedMigration(
-                    to: SimpleSchemaV0_0_3.Test.self,
+            try SimpleSchemaV0_0_3.AddingFieldsModel
+                .fieldsAddedMigration(
+                    to: SimpleSchemaV0_0_5.AddingFieldsModel.self,
                     on: container.context
                 )
         } catch let error as ManagedObjectContextError {
             if
-                case let .fieldMismatch(
+                case let .automaticMigrationRequiresOnlyOptionalFieldsAdded(
                     base,
                     destination
                 ) = error
             {
-                #expect(base.schema == SimpleSchemaV0_0_1.Test.schema)
-                #expect(destination.schema == SimpleSchemaV0_0_3.Test.schema)
+                #expect(base.schema == SimpleSchemaV0_0_3.AddingFieldsModel.schema)
+                #expect(destination.schema == SimpleSchemaV0_0_5.AddingFieldsModel.schema)
                 return
             }
             Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
             return
         } catch {
-            Issue.record("Thrown error does not match expectations: \(error)")
+            Issue.record("Thrown error does not match expectations: \(error.localizedDescription)")
             return
         }
         Issue.record("Unexpectedly no error was thrown")
@@ -277,7 +233,8 @@ fileprivate enum SimpleSchemaV0_0_2: VersionedSchema {
 fileprivate enum SimpleSchemaV0_0_3: VersionedSchema {
     static let version = ModelVersion(0, 0, 3)
     static let models: [any Vein.PersistentModel.Type] = [
-        Test.self
+        Test.self,
+        AddingFieldsModel.self
     ]
     
     // Used to test field mismatch on changing underlying SQLite type
@@ -286,8 +243,21 @@ fileprivate enum SimpleSchemaV0_0_3: VersionedSchema {
         @Field
         var date: Int
         
+        @Field
+        var additionalField: Int?
+        
         init(date: Int) {
             self.date = date
+        }
+    }
+    
+    @Model
+    final class AddingFieldsModel {
+        @Field
+        var value: String
+        
+        init(value: String) {
+            self.value = value
         }
     }
 }
@@ -295,7 +265,8 @@ fileprivate enum SimpleSchemaV0_0_3: VersionedSchema {
 fileprivate enum SimpleSchemaV0_0_4: VersionedSchema {
     static let version = ModelVersion(0, 0, 4)
     static let models: [any Vein.PersistentModel.Type] = [
-        Test.self
+        Test.self,
+        AddingFieldsModel.self
     ]
     
     // Used to test field mismatch on changing field name with consistent field type
@@ -304,13 +275,99 @@ fileprivate enum SimpleSchemaV0_0_4: VersionedSchema {
         @Field
         var addedAt: Date
         
+        @Field
+        var additionalField: Int?
+        
         init(addedAt: Date) {
             self.addedAt = addedAt
         }
     }
+    
+    @Model
+    final class AddingFieldsModel {
+        @Field
+        var value: String
+        
+        @Field
+        var newValue: String?
+        
+        init(value: String) {
+            self.value = value
+        }
+    }
 }
 
-fileprivate enum SimpleMigrationSuccess: SchemaMigrationPlan {
+fileprivate enum SimpleSchemaV0_0_5: VersionedSchema {
+    static let version = ModelVersion(0, 0, 5)
+    static let models: [any Vein.PersistentModel.Type] = [
+        Test.self,
+        AddingFieldsModel.self
+    ]
+    
+    // Used to test field mismatch on changing field name with consistent field type
+    @Model
+    final class Test: Identifiable {
+        @Field
+        var date: Date
+        
+        init(date: Date) {
+            self.date = date
+        }
+    }
+    
+    // Used to test throwing automaticMigrationRequiresOnlyOptionalFieldsAdded
+    // on fieldsAddedMigration
+    @Model
+    final class AddingFieldsModel {
+        @Field
+        var value: String
+        
+        @Field
+        var newValue: String
+        
+        init(value: String, newValue: String) {
+            self.value = value
+            self.newValue = newValue
+        }
+    }
+}
+
+fileprivate enum SimpleSchemaV0_0_6: VersionedSchema {
+    static let version = ModelVersion(0, 0, 6)
+    static let models: [any Vein.PersistentModel.Type] = [
+        Test.self,
+        AddingFieldsModel.self
+    ]
+    
+    // Used to test field mismatch on changing field name with consistent field type
+    @Model
+    final class Test: Identifiable {
+        @Field
+        var addedAt: Date
+        
+        @Field
+        var additionalField: Int?
+        
+        init(addedAt: Date) {
+            self.addedAt = addedAt
+        }
+    }
+    
+    @Model
+    final class AddingFieldsModel {
+        @Field
+        var eulav: String
+        
+        @Field
+        var newValue: String?
+        
+        init(eulav: String) {
+            self.eulav = eulav
+        }
+    }
+}
+
+fileprivate enum SimpleMigration: SchemaMigrationPlan {
     static var schemas: [any Vein.VersionedSchema.Type] {
         [
             SimpleSchemaV0_0_1.self,
@@ -322,7 +379,8 @@ fileprivate enum SimpleMigrationSuccess: SchemaMigrationPlan {
     
     static var stages: [MigrationStage] {
         [
-            migrateV1toV2
+            migrateV1toV2,
+            migrateV3toV4
         ]
     }
     
@@ -336,6 +394,34 @@ fileprivate enum SimpleMigrationSuccess: SchemaMigrationPlan {
             )
             
             try SimpleSchemaV0_0_1.Unused.deleteMigration(on: context)
+        },
+        didMigrate: nil
+    )
+    
+    static let migrateV3toV4 = MigrationStage.complex(
+        fromVersion: SimpleSchemaV0_0_3.self,
+        toVersion: SimpleSchemaV0_0_4.self,
+        willMigrate: { context in
+            try SimpleSchemaV0_0_3
+                .AddingFieldsModel
+                .fieldsAddedMigration(
+                    to: SimpleSchemaV0_0_4.AddingFieldsModel.self,
+                    on: context
+                )
+            
+            let models = try context.fetchAll(
+                SimpleSchemaV0_0_3.Test._PredicateHelper()._builder()
+            )
+            
+            for model in models {
+                let new = SimpleSchemaV0_0_4.Test(
+                    addedAt: Date(timeIntervalSince1970: Double(model.date))
+                )
+                try context.delete(model)
+                try context.insert(new)
+            }
+            
+            try context.cleanupOldSchema(SimpleSchemaV0_0_3.self)
         },
         didMigrate: nil
     )

--- a/Tests/VeinTests/Migrations/Unchanged+Delete.swift
+++ b/Tests/VeinTests/Migrations/Unchanged+Delete.swift
@@ -206,7 +206,7 @@ extension MigrationTests {
         do {
             try SimpleSchemaV0_0_1.Test
                 .unchangedMigration(
-                    to: SimpleSchemaV0_0_3.Test.self,
+                    to: SimpleSchemaV0_0_4.Test.self,
                     on: container.context
                 )
         } catch let error as ManagedObjectContextError {
@@ -217,7 +217,7 @@ extension MigrationTests {
                 ) = error
             {
                 #expect(base.schema == SimpleSchemaV0_0_1.Test.schema)
-                #expect(destination.schema == SimpleSchemaV0_0_3.Test.schema)
+                #expect(destination.schema == SimpleSchemaV0_0_4.Test.schema)
                 return
             }
             Issue.record("Thrown error does not match expectations: \(error.errorDescription)")


### PR DESCRIPTION
fields added migration can be used when only fields were added and the newly added fields are optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retroactive addition of optional fields during schema migrations
  * Migration helper to validate, apply, and register fields-added migrations

* **Bug Fixes**
  * Eager initialization now consistently force-unwraps to avoid inconsistent nil handling
  * New, clearer migration error cases and user-facing messages for migration validation failures

* **Tests**
  * Extensive tests covering fields-added migrations, error scenarios, data preservation, and schema evolution

* **Chores**
  * Lint rule disabled: switch_case_alignment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->