### PR TITLE
fixed crash when using LazyField

### DIFF
--- a/Sources/Vein/Model/Protocols/PersistedField.swift
+++ b/Sources/Vein/Model/Protocols/PersistedField.swift
@@ -8,7 +8,7 @@ public protocol PersistedField: Sendable {
     var isLazy: Bool { get }
     var model: (any PersistentModel)? { get }
     func setStoreToCapturedState(_ state: Any)
-    var wasTouched: Bool { get set }
+    var wasTouched: Bool { get }
     
     static var sqliteTypeName: SQLiteTypeName { get }
 }

--- a/Sources/VeinCore/PropertyWrappers/Fields.swift
+++ b/Sources/VeinCore/PropertyWrappers/Fields.swift
@@ -82,8 +82,8 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
     private func setAndNotify(_ newValue: WrappedType) {
         lock.withLock {
             store = newValue
-            model?.notifyOfChanges()
         }
+        model?.notifyOfChanges()
     }
     
     public func setStoreToCapturedState(_ state: Any) {
@@ -144,8 +144,8 @@ public final class Field<T: Persistable>: PersistedField, @unchecked Sendable {
     private func setAndNotify(_ newValue: WrappedType) {
         lock.withLock {
             store = newValue
-            model?.notifyOfChanges()
         }
+        model?.notifyOfChanges()
     }
     
     public func setStoreToCapturedState(_ state: Any) {

--- a/Sources/VeinCore/PropertyWrappers/Fields.swift
+++ b/Sources/VeinCore/PropertyWrappers/Fields.swift
@@ -46,10 +46,6 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
             }
         }
         set {
-            lock.withLock {
-                readFromStore = true
-            }
-            
             guard
                 let model = model,
                 let context = model.context
@@ -82,6 +78,7 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
     private func setAndNotify(_ newValue: WrappedType) {
         lock.withLock {
             store = newValue
+            readFromStore = true
         }
         model?.notifyOfChanges()
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a crash when using LazyField by adding thread-safe backing storage for the touched flag, tightening protocol requirements, and improving error handling and state mutation flow in both LazyField and Field property wrappers.

## Key Changes

- Thread-safety and backing storage
  - Both LazyField and Field now use a private `_wasTouched: Bool` with a public `wasTouched` computed property that reads/writes under an NSLock.
  - State mutation now assigns via `wasTouched` (the locked accessor) and resets `_wasTouched` when restoring captured state.
  - setAndNotify updates store/readFromStore inside the lock and calls model?.notifyOfChanges() outside the lock to avoid holding the lock while notifying.

- LazyField error handling
  - wrappedValue getter now catches ManagedObjectContextError and:
    - returns nil for `.noSuchTable`
    - returns current cached store for `.unexpectedlyEmptyResult`
    - uses fatalError for other errors
  - This prevents crashes from expected missing-table or empty-result scenarios while preserving fail-fast behavior for unexpected errors.

- API / protocol change
  - PersistedField protocol: `var wasTouched: Bool` changed from get set to get (read-only requirement). Implementations provide a public private(set) computed property.

## Behavioral impact
- Public API surface is stable except for the protocol requirement (wasTouched is now read-only); observable behavior remains consistent, with improved concurrency and safer error handling.
- setStoreToCapturedState now resets the internal touched flag correctly.

## Notable quality
- Clear and careful use of locking (NSLock.withLock) and moving notifications outside the lock reduces race and deadlock risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->