### PR TITLE
Added support for inverse declaration via keypath on one side

### DIFF
--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -17,4 +17,6 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
+          swift-build-flags: --enable-experimental-prebuilts
+          test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -10,7 +10,7 @@ jobs:
   macos:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     container:
-      image: swift:6.2.3-noble
+      image: swift:6.3.2-noble
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
@@ -18,4 +18,4 @@ jobs:
           persist-credentials: false
       - name: Test
         # Disable encryption for testing purposes if needed
-        run: SHOULD_DISABLE_ENCRYPTION=1 swift test
+        run: SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts

--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  macos:
+  linux:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     container:
       image: swift:6.3.2-noble

--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Test macOS
-        run: swift test
+        run: SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -27,6 +27,8 @@ public protocol PersistentModel: AnyObject, Sendable {
     
     static var version: ModelVersion { get }
     
+    static var _inverseFields: [ObjectIdentifier: [String: String]] { get }
+    
     func extractPrimitiveState() -> PrimitiveState
     func applyPrimitiveState(_ state: PrimitiveState)
     

--- a/Sources/VeinCore/Model.swift
+++ b/Sources/VeinCore/Model.swift
@@ -1,6 +1,6 @@
 import Vein
 
-@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_PredicateHelper), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion))
+@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_PredicateHelper), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields))
 @attached(extension, conformances: PersistentModel, Sendable, names: named(version), named(schema))
 @attached(peer, names: arbitrary)
 @attached(memberAttribute)

--- a/Sources/VeinCore/PropertyWrappers/ManyRelationship.swift
+++ b/Sources/VeinCore/PropertyWrappers/ManyRelationship.swift
@@ -103,7 +103,13 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     }
     
     private func updateOtherSide(removed: [T], added: [T]) {
-        guard let model, let context = model.context, let inverseKey else { return }
+        guard let model, let context = model.context else { return }
+        
+        if inverseKey.isNil {
+            inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+        }
+        
+        guard let inverseKey else { return }
         
         for target in removed {
             target._setupFields()

--- a/Sources/VeinCore/PropertyWrappers/OneRelationship.swift
+++ b/Sources/VeinCore/PropertyWrappers/OneRelationship.swift
@@ -126,9 +126,13 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
     }
     
     private func updateOtherSide(isRemoving: Bool) {
+        guard let model, let context = model.context else { return }
+        
+        if inverseKey.isNil {
+            inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+        }
+        
         guard
-            let model,
-            let context = model.context,
             let inverseKey,
             let target = wrappedValue
         else { return }

--- a/Sources/VeinCore/PropertyWrappers/RelationshipMacro.swift
+++ b/Sources/VeinCore/PropertyWrappers/RelationshipMacro.swift
@@ -2,7 +2,7 @@ import Vein
 
 @attached(peer)
 public macro Relationship(
-    inverse: String? = nil,
+    inverse: AnyKeyPath? = nil,
     deleteRule: DeleteRule = .nullify
 ) = #externalMacro(
     module: "VeinCoreMacros",

--- a/Sources/VeinCoreMacros/ModelMacroBase.swift
+++ b/Sources/VeinCoreMacros/ModelMacroBase.swift
@@ -268,7 +268,7 @@ static let _fieldInformation: [Vein.FieldInformation] = [
                 .trimmingCharacters(in: ["?"])
         {
             guard
-                typeDecl == root || typeDecl == "[\(root)]"
+                typeDecl == root || typeDecl == "[\(root)]" || typeDecl == "Array<\(root)>"
             else {
                 throw MacroError.relationshipKeypathDoesNotMatchTypeDeclaration("""
                 \(root) is not compatible with \(typeDecl)

--- a/Sources/VeinCoreMacros/ModelMacroBase.swift
+++ b/Sources/VeinCoreMacros/ModelMacroBase.swift
@@ -67,6 +67,22 @@ public struct ModelMacroBase {
         
         let fieldInformationString = fieldInformation.joined(separator: ",\n    ")
         
+        // MARK: - inverse field data
+        let inverseFieldData: String = relationshipVariables.compactMap {
+            guard
+                let relationshipAttr = findRelationshipAttribute(in: $0),
+                let arguments = relationshipAttr.arguments?.as(LabeledExprListSyntax.self),
+                let inverseArg = arguments.first(where: { $0.label?.text == "inverse" }),
+                let (root, last) = inverseArg.expression.extractKeyPathComponents(),
+                let key = $0.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+            else { return nil }
+            
+            return """
+            map[ObjectIdentifier(\(root).self), default: [:]]["\(last)"] = "\(key)"
+            """
+        }.joined(separator: "\n    ")
+        
+        
         // MARK: - inits and assembly
         let eagerVarInit = eagerFields.initEagerRows()
         let relationshipInit = relationshipFields.initRelationshipRows()
@@ -116,6 +132,13 @@ var _relationships: [any Vein.PersistedRelationship] {
         \(relationshipAccessorSetup)
     ]
 }
+
+static let _inverseFields = {
+    var map = [ObjectIdentifier: [String: String]]()
+    \(inverseFieldData)
+    
+    return map
+}()
 
 static let _fieldInformation: [Vein.FieldInformation] = [
     \(fieldInformationString)
@@ -233,12 +256,25 @@ static let _fieldInformation: [Vein.FieldInformation] = [
         var transformedArguments: [String] = []
         
         if let argumentList = arguments,
-           let inverseArg = argumentList.first(where: { $0.label?.text == "inverse" })/*,
-           let inversePropertyName = inverseArg.expression.extractKeyPathPropertyName()*/
+           let inverseArg = argumentList.first(where: { $0.label?.text == "inverse" }),
+           let (root, last) = inverseArg.expression.extractKeyPathComponents(),
+           let typeDecl = varDecl
+                .bindings
+                .first?
+                .typeAnnotation?
+                .type
+                .description
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: ["?"])
         {
-            // uncomment once keypath is used again with runtime link inference
-            // transformedArguments.append("inverse: \"\(inversePropertyName)\"")
-            transformedArguments.append(inverseArg.description.trimmingCharacters(in: [",", " "]))
+            guard
+                typeDecl == root || typeDecl == "[\(root)]"
+            else {
+                throw MacroError.relationshipKeypathDoesNotMatchTypeDeclaration("""
+                \(root) is not compatible with \(typeDecl)
+                """)
+            }
+            transformedArguments.append("inverse: \"\(last)\"")
         }
         
         if let argumentList = arguments,
@@ -256,6 +292,7 @@ static let _fieldInformation: [Vein.FieldInformation] = [
         return [attribute]
     }
 }
+
 public struct DebugDiag: DiagnosticMessage {
     public let message: String
     public var diagnosticID: MessageID { .init(domain: "VeinMacros", id: "debug") }
@@ -418,18 +455,22 @@ extension String {
 }
 
 extension ExprSyntax {
-    func extractKeyPathPropertyName() -> String? {
+    func extractKeyPathComponents() -> (root: String, last: String)? {
         // Check if the expression is a KeyPath
         guard let keyPath = self.as(KeyPathExprSyntax.self) else {
             return nil
         }
         
         // Get the last component (the property name)
-        guard let lastComponent = keyPath.components.last,
-              let propertyComponent = lastComponent.component.as(KeyPathPropertyComponentSyntax.self) else {
-            return nil
-        }
+        guard
+            let rootComponent = keyPath.root,
+            let lastComponent = keyPath.components.last,
+            let lastPropertyComponent = lastComponent.component.as(KeyPathPropertyComponentSyntax.self)
+        else { return nil }
         
-        return propertyComponent.declName.baseName.text
+        return (
+            root: rootComponent.trimmedDescription,
+            last: lastPropertyComponent.trimmedDescription
+        )
     }
 }

--- a/Sources/VeinCoreMacros/Values/MacroError.swift
+++ b/Sources/VeinCoreMacros/Values/MacroError.swift
@@ -1,4 +1,5 @@
 public enum MacroError: Error {
     case onlyApplicableToClasses
     case noIDVariable
+    case relationshipKeypathDoesNotMatchTypeDeclaration(String)
 }

--- a/Tests/VeinTests/Relationships/RelationshipManyManyTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipManyManyTest.swift
@@ -90,7 +90,7 @@ fileprivate enum V0_0_1: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "tags")
+        @Relationship(inverse: \Post.tags)
         var posts: [Post]
         
         init(name: String) {
@@ -100,7 +100,7 @@ fileprivate enum V0_0_1: VersionedSchema {
     
     @Model
     final class Post: Identifiable {
-        @Relationship(inverse: "posts")
+        @Relationship
         var tags: [Tag]
         
         @Field

--- a/Tests/VeinTests/Relationships/RelationshipManyManyTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipManyManyTest.swift
@@ -91,7 +91,7 @@ fileprivate enum V0_0_1: VersionedSchema {
         var name: String
         
         @Relationship(inverse: \Post.tags)
-        var posts: [Post]
+        var posts: Array<Post>
         
         init(name: String) {
             self.name = name
@@ -101,7 +101,7 @@ fileprivate enum V0_0_1: VersionedSchema {
     @Model
     final class Post: Identifiable {
         @Relationship
-        var tags: [Tag]
+        var tags: Array<Tag>
         
         @Field
         var title: String

--- a/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
@@ -166,7 +166,7 @@ fileprivate enum V0_0_1: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "author")
+        @Relationship(inverse: \Comment.author)
         var comments: [Comment]
         
         init(name: String) {
@@ -176,7 +176,7 @@ fileprivate enum V0_0_1: VersionedSchema {
     
     @Model
     final class Comment: Identifiable {
-        @Relationship(inverse: "comments")
+        @Relationship
         var author: User?
         
         @Field
@@ -197,7 +197,7 @@ fileprivate enum V0_0_2: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "author")
+        @Relationship(inverse: \Comment.author)
         var comments: [Comment]
         
         @Field
@@ -210,7 +210,7 @@ fileprivate enum V0_0_2: VersionedSchema {
     
     @Model
     final class Comment: Identifiable {
-        @Relationship(inverse: "comments")
+        @Relationship
         var author: User?
         
         @Field
@@ -238,7 +238,7 @@ fileprivate enum V0_0_3: VersionedSchema {
         @Field
         var is2faEnabled: Bool = false
         
-        @Relationship(inverse: "authors")
+        @Relationship(inverse: \Comment.authors)
         var comments: [Comment]
         
         init(name: String) {
@@ -249,7 +249,7 @@ fileprivate enum V0_0_3: VersionedSchema {
     @Model
     final class Comment: Identifiable {
         // Migration target: changed from author: User? to authors: [User]
-        @Relationship(inverse: "comments")
+        @Relationship
         var authors: [User]
         
         @Field

--- a/Tests/VeinTests/Relationships/RelationshipSelfReferentialTree.swift
+++ b/Tests/VeinTests/Relationships/RelationshipSelfReferentialTree.swift
@@ -37,10 +37,10 @@ fileprivate enum V0_0_1: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "children")
+        @Relationship(inverse: \Category.children)
         var parent: Category?
         
-        @Relationship(inverse: "parent")
+        @Relationship
         var children: [Category]
         
         init(name: String) {

--- a/Tests/VeinTests/Relationships/RelationshipUpdateTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipUpdateTest.swift
@@ -87,7 +87,7 @@ fileprivate enum V0_0_1: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "author")
+        @Relationship(inverse: \Comment.author)
         var comments: [Comment]
         
         init(name: String) {
@@ -97,7 +97,7 @@ fileprivate enum V0_0_1: VersionedSchema {
     
     @Model
     final class Comment: Identifiable {
-        @Relationship(inverse: "comments")
+        @Relationship
         var author: User?
         
         @Field

--- a/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
@@ -207,7 +207,7 @@ fileprivate enum CommentRelationshipCascade: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "author", deleteRule: .cascade)
+        @Relationship(inverse: \Comment.author, deleteRule: .cascade)
         var comments: [Comment]
         
         init(name: String) {
@@ -221,7 +221,7 @@ fileprivate enum CommentRelationshipCascade: VersionedSchema {
     
     @Model
     final class Comment: Identifiable {
-        @Relationship(inverse: "comments")
+        @Relationship
         var author: User?
         
         @Field
@@ -250,7 +250,7 @@ fileprivate enum RelationshipCascadeCascade: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "author", deleteRule: .cascade)
+        @Relationship(deleteRule: .cascade)
         var comments: [Comment]
         
         init(name: String) {
@@ -264,7 +264,7 @@ fileprivate enum RelationshipCascadeCascade: VersionedSchema {
     
     @Model
     final class Comment: Identifiable {
-        @Relationship(inverse: "comments", deleteRule: .cascade)
+        @Relationship(inverse: \User.comments, deleteRule: .cascade)
         var author: User?
         
         @Field
@@ -293,7 +293,7 @@ fileprivate enum CommentRelationshipNullify: VersionedSchema {
         @Field
         var name: String
         
-        @Relationship(inverse: "author")
+        @Relationship(inverse: \Comment.author)
         var comments: [Comment]
         
         init(name: String) {
@@ -307,7 +307,7 @@ fileprivate enum CommentRelationshipNullify: VersionedSchema {
     
     @Model
     final class Comment: Identifiable {
-        @Relationship(inverse: "comments")
+        @Relationship
         var author: User?
         
         @Field


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces support for specifying inverse relationships using Swift keypaths instead of string literals, enabling more type-safe and refactoring-friendly relationship declarations in the Vein MOC framework.

### Key Changes

**Protocol & Macro Updates:**
- Added `static var _inverseFields: [ObjectIdentifier: [String: String]] { get }` requirement to `PersistentModel` protocol to store computed inverse field mappings
- Updated `Model()` macro to support generating the `_inverseFields` property
- Changed `Relationship` macro's `inverse` parameter type from `String?` to `AnyKeyPath?` for type-safe keypath declarations

**Relationship Implementation:**
- Enhanced `OneRelationship.updateOtherSide(isRemoving:)` and `ManyRelationship.updateOtherSide(removed:added:)` to lazily derive inverse keys from the `_inverseFields` mapping when not explicitly set
- This allows relationships to work correctly even when the inverse is declared via keypath on the other side

**Macro Expansion Logic:**
- `ModelMacroBase` now parses keypath-based `inverse` declarations and validates that the parsed keypath's root type matches the property's declared type (handling both direct types and collection-wrapped types like `[Model]`)
- Generates the `_inverseFields` mapping from all relationship declarations
- Added `MacroError.relationshipKeypathDoesNotMatchTypeDeclaration` for type mismatch validation

**Test Coverage & CI/CD:**
- Updated all relationship tests (`RelationshipManyManyTest`, `RelationshipMigrationTest`, `RelationshipSelfReferentialTree`, `RelationshipUpdateTest`, `RelationshiptDeleteRuleTest`) to use the new keypath syntax (e.g., `@Relationship(inverse: \Post.tags)` instead of `@Relationship(inverse: "posts")`)
- CI/CD workflows updated to enable experimental Swift prebuilts and set `SHOULD_DISABLE_ENCRYPTION=1` environment variable

### Highlights

This is an excellent improvement to the API design. The shift from error-prone string-based inverse declarations to compile-checked keypaths significantly improves type safety and refactoring capabilities. The implementation properly validates that keypaths match their corresponding property types, catching configuration errors at macro expansion time rather than runtime. The lazy inverse key derivation is a particularly thoughtful design choice that enables flexibility in how developers specify relationships while maintaining bidirectional consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->