### PR TITLE
Added tsan test, merged ULID lib into vein package + fixed one warning related to ulid

### DIFF
--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -18,4 +18,4 @@ jobs:
           persist-credentials: false
       - name: Test
         # Disable encryption for testing purposes if needed
-        run: SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts
+        run: ./Scripts/tsan-test.sh

--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Test macOS
-        run: SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts
+        run: ./Scripts/tsan-test.sh

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import CompilerPluginSupport
 var veinDependencies: [Target.Dependency] = [
     .product(name: "Crypto", package: "swift-crypto"),
     .product(name: "SQLiteDB", package: "swift-sqlcipher"),
-    .product(name: "ULID", package: "ULID.swift"),
+    "ULID",
     .product(name: "Logging", package: "swift-log"),
     .product(
         name: "KeychainAccess",
@@ -45,6 +45,10 @@ let package = Package(
         .library(
             name: "VeinTesting",
             targets: ["VeinTesting"]
+        ),
+        .library(
+            name: "ULID",
+            targets: ["ULID"]
         )
     ],
     dependencies: [
@@ -58,7 +62,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "610.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.9.1")),
-        .package(url: "https://github.com/yaslab/ULID.swift", .upToNextMajor(from: "1.3.1")),
         .package(url: "https://github.com/kishikawakatsumi/keychainaccess", .upToNextMajor(from: "4.2.2")),
         .package(url: "https://github.com/amethystsoft/KeyringAccess", .upToNextMajor(from: "1.0.0")),
     ],
@@ -113,6 +116,7 @@ let package = Package(
                 .product(name: "VeinMacrosCore", package: "VeinMacrosCore")
             ],
         ),
+        .target(name: "ULID"),
         .testTarget(
             name: "VeinTests",
             dependencies: [
@@ -130,6 +134,10 @@ let package = Package(
                 "VeinCore",
                 .product(name: "Logging", package: "swift-log")
             ]
+        ),
+        .testTarget(
+            name: "ULIDTests",
+            dependencies: ["ULID"]
         )
     ]
 )

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,0 +1,1 @@
+SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts

--- a/Scripts/tsan-test.sh
+++ b/Scripts/tsan-test.sh
@@ -1,0 +1,1 @@
+TSAN_OPTIONS="suppressions=tsan_suppressions.txt" SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts --sanitize=thread

--- a/Scripts/tsan-test.sh
+++ b/Scripts/tsan-test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+TSAN_OPTIONS="suppressions=tsan_suppressions.txt" SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts --sanitize=thread

--- a/Sources/ULID/Data+Base32.swift
+++ b/Sources/ULID/Data+Base32.swift
@@ -1,0 +1,183 @@
+//
+//  Data+Base32.swift
+//  ULID
+//
+//  Created by Yasuhiro Hatta on 2019/01/11.
+//  Copyright © 2019 yaslab. All rights reserved.
+//
+
+import Foundation
+
+enum Base32 {
+
+    static let crockfordsEncodingTable: [UInt8] = Array("0123456789ABCDEFGHJKMNPQRSTVWXYZ".utf8)
+
+    static let crockfordsDecodingTable: [UInt8] = [
+        // 0     1     2     3     4     5     6     7     8     9     a     b     c     d     e     f
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 0
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 1
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 2
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 3
+        0xff, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x01, 0x12, 0x13, 0x01, 0x14, 0x15, 0x00, // 4
+        0x16, 0x17, 0x18, 0x19, 0x1a, 0xff, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, // 5
+        0xff, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x01, 0x12, 0x13, 0x01, 0x14, 0x15, 0x00, // 6
+        0x16, 0x17, 0x18, 0x19, 0x1a, 0xff, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0xff, 0xff, 0xff, 0xff, 0xff, // 7
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 8
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 9
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // a
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // b
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // c
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // d
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // e
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // f
+    ]
+
+}
+
+extension Data {
+
+    /// Decode Crockford's Base32
+    init?(base32Encoded base32String: String, using table: [UInt8] = Base32.crockfordsDecodingTable) {
+        var base32String = base32String
+        if base32String.last == "=", let index = base32String.lastIndex(where: { $0 != "=" }) {
+            base32String = String(base32String[...index])
+        }
+
+        let src = base32String.utf8
+        guard [0, 2, 4, 5, 7].contains(src.count % 8) else {
+            return nil
+        }
+        var srcleft = src.count
+        var srci = 0
+
+        let dstlen = src.count * 5 / 8
+        let dst = UnsafeMutablePointer<UInt8>.allocate(capacity: dstlen)
+        var dsti = 0
+        defer { dst.deallocate() }
+
+        let work = UnsafeMutablePointer<UInt8>.allocate(capacity: 8)
+        defer { work.deallocate() }
+
+        while srcleft > 0 {
+            let worklen = Swift.min(8, srcleft)
+            for i in 0 ..< worklen {
+                work[i] = table[Int(src[src.index(src.startIndex, offsetBy: srci + i)])]
+                if work[i] == 0xff {
+                    return nil
+                }
+            }
+
+            switch worklen {
+            case 8:
+                dst[dsti + 4] = (work[6] << 5) | (work[7]     )
+                fallthrough
+            case 7:
+                dst[dsti + 3] = (work[4] << 7) | (work[5] << 2) | (work[6] >> 3)
+                fallthrough
+            case 5:
+                dst[dsti + 2] = (work[3] << 4) | (work[4] >> 1)
+                fallthrough
+            case 4:
+                dst[dsti + 1] = (work[1] << 6) | (work[2] << 1) | (work[3] >> 4)
+                fallthrough
+            case 2:
+                dst[dsti + 0] = (work[0] << 3) | (work[1] >> 2)
+            default:
+                break
+            }
+
+            srci += 8
+            srcleft -= 8
+            dsti += 5
+        }
+
+        self = Data(bytes: dst, count: dstlen)
+    }
+
+    /// Encode Crockford's Base32
+    func base32EncodedString(padding: Bool = true, using table: [UInt8] = Base32.crockfordsEncodingTable) -> String {
+        return self.withUnsafeBytes { (src: UnsafeRawBufferPointer) -> String in
+            var srcleft = src.count
+            var srci = 0
+
+            let dstlen: Int
+            if padding {
+                dstlen = (src.count + 4) / 5 * 8
+            } else {
+                dstlen = (src.count * 8 + 4) / 5
+            }
+            var dstleft = dstlen
+            let dst = UnsafeMutablePointer<UInt8>.allocate(capacity: dstlen + 1)
+            var dstp = dst
+            defer { dst.deallocate() }
+
+            let work = UnsafeMutablePointer<UInt8>.allocate(capacity: 8)
+            work.initialize(repeating: 0, count: 8)
+            defer { work.deallocate() }
+
+            while srcleft > 0 {
+                switch srcleft {
+                case _ where 5 <= srcleft:
+                    work[7]  = src[srci + 4]
+                    work[6]  = src[srci + 4] >> 5
+                    fallthrough
+                case 4:
+                    work[6] |= src[srci + 3] << 3
+                    work[5]  = src[srci + 3] >> 2
+                    work[4]  = src[srci + 3] >> 7
+                    fallthrough
+                case 3:
+                    work[4] |= src[srci + 2] << 1
+                    work[3]  = src[srci + 2] >> 4
+                    fallthrough
+                case 2:
+                    work[3] |= src[srci + 1] << 4
+                    work[2]  = src[srci + 1] >> 1
+                    work[1]  = src[srci + 1] >> 6
+                    fallthrough
+                case 1:
+                    work[1] |= src[srci + 0] << 2
+                    work[0]  = src[srci + 0] >> 3
+                default:
+                    break
+                }
+
+                for i in 0 ..< Swift.min(8, dstleft) {
+                    dstp[i] = table[Int(work[i] & 0x1f)]
+                }
+
+                if srcleft < 5 {
+                    if padding {
+                        switch srcleft {
+                        case 1:
+                            dstp[2] = 0x3d
+                            dstp[3] = 0x3d
+                            fallthrough
+                        case 2:
+                            dstp[4] = 0x3d
+                            fallthrough
+                        case 3:
+                            dstp[5] = 0x3d
+                            dstp[6] = 0x3d
+                            fallthrough
+                        case 4:
+                            dstp[7] = 0x3d
+                        default:
+                            break
+                        }
+                    }
+                    break
+                }
+
+                srci += 5
+                srcleft -= 5
+                dstp += 8
+                dstleft -= 8
+            }
+
+            dst[dstlen] = 0
+            return String(cString: dst)
+        }
+    }
+
+}

--- a/Sources/ULID/ULID.swift
+++ b/Sources/ULID/ULID.swift
@@ -1,0 +1,251 @@
+//
+//  ULID.swift
+//  ULID
+//
+//  Created by Yasuhiro Hatta on 2019/01/11.
+//  Copyright © 2019 yaslab. All rights reserved.
+//
+//  Adapted for Amethyst Vein to resolve concurrent metadata TSan false positives.
+
+import Foundation
+
+public typealias ulid_t = uuid_t
+
+/// Universally Unique Lexicographically Sortable Identifier.
+public struct ULID: Hashable, Equatable, Comparable, CustomStringConvertible, Sendable {
+
+    public private(set) var ulid: ulid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+    /// Create a ULID from a `ulid_t`.
+    public init(ulid: ulid_t) {
+        self.ulid = ulid
+    }
+
+    /// Create a ULID from a data.
+    public init?(ulidData data: Data) {
+        guard data.count == 16 else {
+            return nil
+        }
+        withUnsafeMutableBytes(of: &ulid) {
+            $0.copyBytes(from: data)
+        }
+    }
+
+    /// Create a ULID from a string.
+    public init?(ulidString string: String) {
+        guard string.utf8.count == 26, let data = Data(base32Encoded: "000000" + string) else {
+            return nil
+        }
+        withUnsafeMutableBytes(of: &ulid) {
+            $0.copyBytes(from: data.dropFirst(4))
+        }
+    }
+    
+    /// Create a ULID from a timestamp and a random part.
+    ///
+    /// - Parameters:
+    ///   - timestamp: Specify the timestamp as `Date`.
+    ///   - data: Data representation of the random part of the ULID.
+    /// - Returns: **nil** if the `data` is less than 80 bits or 10 bytes in size.
+    public init?(timestamp: Date = Date(), randomPartData data: Data){
+        let randomDataInBytes = 10
+        guard data.count >= randomDataInBytes else { return nil }
+        
+        withUnsafeMutableBytes(of: &ulid) { (buffer) in
+            var i = 0
+            var millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0).bigEndian
+            withUnsafeBytes(of: &millisec) {
+                for j in 2 ..< 8 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+            var randomPart:Data = Data()
+            if data.count > randomDataInBytes{
+                randomPart = data.prefix(randomDataInBytes)
+            }else{
+                randomPart = data
+            }
+            
+            withUnsafeBytes(of: &randomPart) {
+                for j in 0 ..< 10 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+        }
+    }
+
+    /// Create a ULID with the given timestamp and random number generator.
+    public init<T: RandomNumberGenerator>(timestamp: Date, generator: inout T) {
+        withUnsafeMutableBytes(of: &ulid) { (buffer) in
+            var i = 0
+            var millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0).bigEndian
+            withUnsafeBytes(of: &millisec) {
+                for j in 2 ..< 8 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+            var random16 = UInt16.random(in: .min ... .max, using: &generator).bigEndian
+            withUnsafeBytes(of: &random16) {
+                for j in 0 ..< 2 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+            var random64 = UInt64.random(in: .min ... .max, using: &generator).bigEndian
+            withUnsafeBytes(of: &random64) {
+                for j in 0 ..< 8 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+        }
+    }
+
+    /// Create a ULID with the given timestamp.
+    public init(timestamp: Date = Date()) {
+        var generator = SystemRandomNumberGenerator()
+        withUnsafeMutableBytes(of: &ulid) { (buffer) in
+            var i = 0
+            var millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0).bigEndian
+            withUnsafeBytes(of: &millisec) {
+                for j in 2 ..< 8 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+            var random16 = UInt16.random(in: .min ... .max, using: &generator).bigEndian
+            withUnsafeBytes(of: &random16) {
+                for j in 0 ..< 2 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+            var random64 = UInt64.random(in: .min ... .max, using: &generator).bigEndian
+            withUnsafeBytes(of: &random64) {
+                for j in 0 ..< 8 {
+                    buffer[i] = $0[j]
+                    i += 1
+                }
+            }
+        }
+    }
+
+    /// Returns a raw binary data.
+    public var ulidData: Data {
+        return withUnsafeBytes(of: ulid) {
+            return Data(buffer: $0.bindMemory(to: UInt8.self))
+        }
+    }
+
+    /// Returns a string created from the ULID.
+    public var ulidString: String {
+        return withUnsafeBytes(of: ulid) {
+            var data = Data(count: 4)
+            data.append($0.bindMemory(to: UInt8.self))
+            return String(data.base32EncodedString().dropFirst(6))
+        }
+    }
+
+    /// Returns the timestamp part of the ULID.
+    public var timestamp: Date {
+        return withUnsafeBytes(of: ulid) { (buffer) in
+            var millisec: UInt64 = 0
+            withUnsafeMutableBytes(of: &millisec) {
+                for i in 0 ..< 6 {
+                    $0[2 + i] = buffer[i]
+                }
+            }
+            return Date(timeIntervalSince1970: TimeInterval(millisec.bigEndian) / 1000.0)
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ulid.0)
+        hasher.combine(ulid.1)
+        hasher.combine(ulid.2)
+        hasher.combine(ulid.3)
+        hasher.combine(ulid.4)
+        hasher.combine(ulid.5)
+        hasher.combine(ulid.6)
+        hasher.combine(ulid.7)
+        hasher.combine(ulid.8)
+        hasher.combine(ulid.9)
+        hasher.combine(ulid.10)
+        hasher.combine(ulid.11)
+        hasher.combine(ulid.12)
+        hasher.combine(ulid.13)
+        hasher.combine(ulid.14)
+        hasher.combine(ulid.15)
+    }
+
+    public static func == (lhs: ULID, rhs: ULID) -> Bool {
+        return lhs.ulid.0 == rhs.ulid.0
+            && lhs.ulid.1 == rhs.ulid.1
+            && lhs.ulid.2 == rhs.ulid.2
+            && lhs.ulid.3 == rhs.ulid.3
+            && lhs.ulid.4 == rhs.ulid.4
+            && lhs.ulid.5 == rhs.ulid.5
+            && lhs.ulid.6 == rhs.ulid.6
+            && lhs.ulid.7 == rhs.ulid.7
+            && lhs.ulid.8 == rhs.ulid.8
+            && lhs.ulid.9 == rhs.ulid.9
+            && lhs.ulid.10 == rhs.ulid.10
+            && lhs.ulid.11 == rhs.ulid.11
+            && lhs.ulid.12 == rhs.ulid.12
+            && lhs.ulid.13 == rhs.ulid.13
+            && lhs.ulid.14 == rhs.ulid.14
+            && lhs.ulid.15 == rhs.ulid.15
+    }
+
+    public static func < (lhs: ULID, rhs: ULID) -> Bool {
+        if lhs.ulid.0 != rhs.ulid.0 { return lhs.ulid.0 < rhs.ulid.0 }
+        if lhs.ulid.1 != rhs.ulid.1 { return lhs.ulid.1 < rhs.ulid.1 }
+        if lhs.ulid.2 != rhs.ulid.2 { return lhs.ulid.2 < rhs.ulid.2 }
+        if lhs.ulid.3 != rhs.ulid.3 { return lhs.ulid.3 < rhs.ulid.3 }
+        if lhs.ulid.4 != rhs.ulid.4 { return lhs.ulid.4 < rhs.ulid.4 }
+        if lhs.ulid.5 != rhs.ulid.5 { return lhs.ulid.5 < rhs.ulid.5 }
+        if lhs.ulid.6 != rhs.ulid.6 { return lhs.ulid.6 < rhs.ulid.6 }
+        if lhs.ulid.7 != rhs.ulid.7 { return lhs.ulid.7 < rhs.ulid.7 }
+        if lhs.ulid.8 != rhs.ulid.8 { return lhs.ulid.8 < rhs.ulid.8 }
+        if lhs.ulid.9 != rhs.ulid.9 { return lhs.ulid.9 < rhs.ulid.9 }
+        if lhs.ulid.10 != rhs.ulid.10 { return lhs.ulid.10 < rhs.ulid.10 }
+        if lhs.ulid.11 != rhs.ulid.11 { return lhs.ulid.11 < rhs.ulid.11 }
+        if lhs.ulid.12 != rhs.ulid.12 { return lhs.ulid.12 < rhs.ulid.12 }
+        if lhs.ulid.13 != rhs.ulid.13 { return lhs.ulid.13 < rhs.ulid.13 }
+        if lhs.ulid.14 != rhs.ulid.14 { return lhs.ulid.14 < rhs.ulid.14 }
+        return lhs.ulid.15 < rhs.ulid.15
+    }
+
+    public var description: String {
+        return ulidString
+    }
+
+}
+
+extension ULID: Codable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+
+        guard let ulid = ULID(ulidString: string) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Attempted to decode ULID from invalid ULID string."
+                )
+            )
+        }
+
+        self = ulid
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.ulidString)
+    }
+
+}

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
@@ -35,15 +35,21 @@ extension ManagedObjectContext {
         }
         
         var sortedModels: [T] = []
+        let isInMigration = isInActiveMigration.value
         for id in ids {
             if let model = models[id] {
                 model._observers.value[observer.id] = observer.block
                 sortedModels.append(model)
             } else {
-                Self.logger.warning("""
-                    Mismatch between Relationship IDs and existing models. \
-                    Potential data corruption.
-                """)
+                if !isInMigration {
+                    Self.logger.warning(
+                        "Relationship ID mismatch for \(T.self). Potential data corruption."
+                    )
+                } else {
+                    Self.logger.info(
+                        "[Migration] Relationship ID mismatch for \(T.self). Verify migration integrity if unexpected."
+                    )
+                }
             }
         }
         

--- a/Tests/ULIDTests/Data+Base32Tests.swift
+++ b/Tests/ULIDTests/Data+Base32Tests.swift
@@ -1,0 +1,228 @@
+//
+//  Data+Base32Tests.swift
+//  ULIDTests
+//
+//  Created by Yasuhiro Hatta on 2019/01/12.
+//  Copyright © 2019 yaslab. All rights reserved.
+//
+#if os(macOS)
+import XCTest
+@testable import ULID
+
+final class Base32Tests: XCTestCase {
+
+    // MARK: -
+    // MARK: Encode
+
+    func testEncodeBase32() {
+        let expected = "00000001D0YX86C6ZTSZJNXFHDQMCYBQ"
+
+        let bytes: [UInt8] = [
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x68, 0x3D, 0xD4, 0x19, 0x86,
+            0xFE, 0xB3, 0xF9, 0x57, 0xAF, 0x8B, 0x6F, 0x46, 0x79, 0x77
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual(expected, data.base32EncodedString())
+    }
+
+    func testEncode1() {
+        let bytes: [UInt8] = [
+            0b11111000, 0b00000000, 0b00000000, 0b00000000, 0b00000000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("Z0000000", data.base32EncodedString())
+    }
+
+    func testEncode2() {
+        let bytes: [UInt8] = [
+            0b00000111, 0b11000000, 0b00000000, 0b00000000, 0b00000000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("0Z000000", data.base32EncodedString())
+    }
+
+    func testEncode3() {
+        let bytes: [UInt8] = [
+            0b00000000, 0b00111110, 0b00000000, 0b00000000, 0b00000000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("00Z00000", data.base32EncodedString())
+    }
+
+    func testEncode4() {
+        let bytes: [UInt8] = [
+            0b00000000, 0b00000001, 0b11110000, 0b00000000, 0b00000000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("000Z0000", data.base32EncodedString())
+    }
+
+    func testEncode5() {
+        let bytes: [UInt8] = [
+            0b00000000, 0b00000000, 0b00001111, 0b10000000, 0b00000000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("0000Z000", data.base32EncodedString())
+    }
+
+    func testEncode6() {
+        let bytes: [UInt8] = [
+            0b00000000, 0b00000000, 0b00000000, 0b01111100, 0b00000000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("00000Z00", data.base32EncodedString())
+    }
+
+    func testEncode7() {
+        let bytes: [UInt8] = [
+            0b00000000, 0b00000000, 0b00000000, 0b00000011, 0b11100000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("000000Z0", data.base32EncodedString())
+    }
+
+    func testEncode8() {
+        let bytes: [UInt8] = [
+            0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00011111
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("0000000Z", data.base32EncodedString())
+    }
+
+    func testEncodePad1() {
+        let bytes: [UInt8] = [
+            0b10000100
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("GG======", data.base32EncodedString())
+    }
+
+    func testEncodePad2() {
+        let bytes: [UInt8] = [
+            0b10000100, 0b00100001
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("GGGG====", data.base32EncodedString())
+    }
+
+    func testEncodePad3() {
+        let bytes: [UInt8] = [
+            0b10000100, 0b00100001, 0b00001000
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("GGGGG===", data.base32EncodedString())
+    }
+
+    func testEncodePad4() {
+        let bytes: [UInt8] = [
+            0b10000100, 0b00100001, 0b00001000, 0b01000010
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("GGGGGGG=", data.base32EncodedString())
+    }
+
+    func testEncodeNoPad() {
+        let bytes: [UInt8] = [
+            0b10000100
+        ]
+        let data = Data(bytes)
+
+        XCTAssertEqual("GG", data.base32EncodedString(padding: false))
+    }
+
+    // MARK: -
+    // MARK: Decode
+
+    func testDecodeBase32() {
+        let expected: [UInt8] = [
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x68, 0x3D, 0xD4, 0x19, 0x86,
+            0xFE, 0xB3, 0xF9, 0x57, 0xAF, 0x8B, 0x6F, 0x46, 0x79, 0x77
+        ]
+
+        let base32String = "00000001D0YX86C6ZTSZJNXFHDQMCYBQ"
+        let data = Data(base32Encoded: base32String)
+
+        XCTAssertNotNil(data)
+        XCTAssertEqual(expected, Array(data!))
+    }
+
+    func testDecodeTable() {
+        let table: [Character: UInt8] = [
+            "0": 0x00, "O": 0x00, "o": 0x00,
+            "1": 0x01, "I": 0x01, "i": 0x01, "L": 0x01, "l": 0x01,
+            "2": 0x02,
+            "3": 0x03,
+            "4": 0x04,
+            "5": 0x05,
+            "6": 0x06,
+            "7": 0x07,
+            "8": 0x08,
+            "9": 0x09,
+            "A": 0x0a, "a": 0x0a,
+            "B": 0x0b, "b": 0x0b,
+            "C": 0x0c, "c": 0x0c,
+            "D": 0x0d, "d": 0x0d,
+            "E": 0x0e, "e": 0x0e,
+            "F": 0x0f, "f": 0x0f,
+            "G": 0x10, "g": 0x10,
+            "H": 0x11, "h": 0x11,
+            "J": 0x12, "j": 0x12,
+            "K": 0x13, "k": 0x13,
+            "M": 0x14, "m": 0x14,
+            "N": 0x15, "n": 0x15,
+            "P": 0x16, "p": 0x16,
+            "Q": 0x17, "q": 0x17,
+            "R": 0x18, "r": 0x18,
+            "S": 0x19, "s": 0x19,
+            "T": 0x1a, "t": 0x1a,
+            "V": 0x1b, "v": 0x1b,
+            "W": 0x1c, "w": 0x1c,
+            "X": 0x1d, "x": 0x1d,
+            "Y": 0x1e, "y": 0x1e,
+            "Z": 0x1f, "z": 0x1f
+        ]
+
+        for (char, value) in table {
+            let data = Data(base32Encoded: String(char) + "0")
+            XCTAssertNotNil(data)
+            XCTAssertEqual(1, data!.count)
+            XCTAssertEqual(value << 3, data![0])
+        }
+    }
+
+    func testDecodeInvalidCharacter() {
+        let invalidCharacters = ["U", "u", "*", "~", "$", "="]
+
+        for char in invalidCharacters {
+            let data = Data(base32Encoded: char + "0")
+            XCTAssertNil(data)
+        }
+    }
+
+    func testDecodePadding() {
+        let data = Data(base32Encoded: "AM======")
+        XCTAssertNotNil(data)
+        XCTAssertEqual(1, data!.count)
+        XCTAssertEqual(0b01010101, data![0])
+    }
+
+    func testDecodeIncorrectLength() {
+        let data = Data(base32Encoded: "0")
+        XCTAssertNil(data)
+    }
+
+}
+#endif

--- a/Tests/ULIDTests/ULIDTests.swift
+++ b/Tests/ULIDTests/ULIDTests.swift
@@ -1,0 +1,298 @@
+//
+//  ULIDTests.swift
+//  ULIDTests
+//
+//  Created by Yasuhiro Hatta on 2019/01/11.
+//  Copyright © 2019 yaslab. All rights reserved.
+//
+#if os(macOS)
+import XCTest
+import ULID
+
+final class ULIDTests: XCTestCase {
+
+    func testGenerateTimestamp() {
+        let expected: [UInt8] = [
+            0x01, 0x68, 0x3D, 0x17, 0x73, 0x09, 0xE5
+        ]
+
+        let timestamp = Date(timeIntervalSince1970: 1547213173.513)
+        let actual = ULID(timestamp: timestamp)
+
+        XCTAssertEqual(expected[0], actual.ulid.0)
+        XCTAssertEqual(expected[1], actual.ulid.1)
+        XCTAssertEqual(expected[2], actual.ulid.2)
+        XCTAssertEqual(expected[3], actual.ulid.3)
+        XCTAssertEqual(expected[4], actual.ulid.4)
+        XCTAssertEqual(expected[5], actual.ulid.5)
+
+        XCTAssertEqual(timestamp, actual.timestamp)
+
+        XCTAssertEqual(Array(expected.prefix(6)), Array(actual.ulidData.prefix(6)))
+
+        XCTAssertEqual("01D0YHEWR9", actual.ulidString.prefix(10))
+    }
+    
+    func testGenerateTimestampAndRandomnes(){
+        let timestamp = Date(timeIntervalSince1970: 1547213173.513)
+        let uuidCorrectSize: [UInt8] = [
+            0x01, 0x68, 0x3D, 0x17, 0x73, 0x09, 0x69, 0xF4, 0xA2, 0xB1
+        ]
+        
+        let actual = ULID(timestamp: timestamp, randomPartData: Data(uuidCorrectSize))!
+        XCTAssertEqual(timestamp, actual.timestamp)
+        
+        XCTAssertEqual(0x01, actual.ulid.6)
+        XCTAssertEqual(0x68, actual.ulid.7)
+        XCTAssertEqual(0x3D, actual.ulid.8)
+        XCTAssertEqual(0x17, actual.ulid.9)
+        XCTAssertEqual(0x73, actual.ulid.10)
+        XCTAssertEqual(0x09, actual.ulid.11)
+        XCTAssertEqual(0x69, actual.ulid.12)
+        XCTAssertEqual(0xF4, actual.ulid.13)
+        XCTAssertEqual(0xA2, actual.ulid.14)
+        XCTAssertEqual(0xB1, actual.ulid.15)
+
+        
+        
+        //Test if initializer discards bytes beyond 10 bytes
+        let uuidTooBigSize: [UInt8] = [
+            0x01, 0x68, 0x3D, 0x17, 0x73, 0x09, 0x69, 0xF4, 0xA2, 0xB1, 0x99, 0x55
+        ]
+        
+        let actual2 = ULID(timestamp: timestamp, randomPartData: Data(uuidTooBigSize))!
+        XCTAssertEqual(timestamp, actual.timestamp)
+        
+        XCTAssertEqual(0x01, actual2.ulid.6)
+        XCTAssertEqual(0x68, actual2.ulid.7)
+        XCTAssertEqual(0x3D, actual2.ulid.8)
+        XCTAssertEqual(0x17, actual2.ulid.9)
+        XCTAssertEqual(0x73, actual2.ulid.10)
+        XCTAssertEqual(0x09, actual2.ulid.11)
+        XCTAssertEqual(0x69, actual2.ulid.12)
+        XCTAssertEqual(0xF4, actual2.ulid.13)
+        XCTAssertEqual(0xA2, actual2.ulid.14)
+        XCTAssertEqual(0xB1, actual2.ulid.15)
+        
+        
+        let uuidTooSmallSize: [UInt8] = [
+            0x01, 0x68, 0x3D, 0x17, 0x73,
+        ]
+        
+        XCTAssertNil(ULID(timestamp: timestamp, randomPartData: Data(uuidTooSmallSize)))
+    }
+
+    func testGenerateRandomness() {
+        let timestamp = Date(timeIntervalSince1970: 1547213173.513)
+        var generator = MockRandomNumberGenerator(value: 0x1122334455667788)
+        let actual = ULID(timestamp: timestamp, generator: &generator)
+
+        XCTAssertEqual(timestamp, actual.timestamp)
+
+        XCTAssertEqual(0x77, actual.ulid.6)
+        XCTAssertEqual(0x88, actual.ulid.7)
+        XCTAssertEqual(0x11, actual.ulid.8)
+        XCTAssertEqual(0x22, actual.ulid.9)
+        XCTAssertEqual(0x33, actual.ulid.10)
+        XCTAssertEqual(0x44, actual.ulid.11)
+        XCTAssertEqual(0x55, actual.ulid.12)
+        XCTAssertEqual(0x66, actual.ulid.13)
+        XCTAssertEqual(0x77, actual.ulid.14)
+        XCTAssertEqual(0x88, actual.ulid.15)
+    }
+
+    func testParseULIDString() {
+        let expected = "01D0YHEWR9WMPY4NNTPK1MR1TQ"
+
+        let actual = ULID(ulidString: expected)
+
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(expected, actual!.ulidString)
+    }
+
+    func testParseULIDStringError() {
+        let zero = ""
+        XCTAssertNil(ULID(ulidString: zero))
+    }
+
+    func testParseULIDData() {
+        let expected: [UInt8] = [
+            0x01, 0x68, 0x3D, 0x17, 0x73, 0x09, 0xE5, 0x2D,
+            0xE2, 0x56, 0xBA, 0xB4, 0xC3, 0x4C, 0x07, 0x57
+        ]
+
+        let actual = ULID(ulidData: Data(expected))
+
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(expected, Array(actual!.ulidData))
+    }
+
+    func testParseULIDDataError() {
+        let zero = Data()
+        XCTAssertNil(ULID(ulidData: zero))
+    }
+
+    func testULIDDataLength() {
+        let ulid = ULID()
+        XCTAssertEqual(16, ulid.ulidData.count)
+    }
+
+    func testULIDStringLength() {
+        let ulid = ULID()
+        XCTAssertEqual(26, ulid.ulidString.count)
+    }
+
+    func testHashable1() {
+        // Note: Hash values are not guaranteed to be equal across different executions.
+        let ulid1 = ULID()
+        let ulid2 = ULID(ulid: ulid1.ulid)
+        XCTAssertEqual(ulid1.hashValue, ulid2.hashValue)
+    }
+
+    func testHashable2() {
+        let timestamp = Date(timeIntervalSince1970: 1547213173.513)
+
+        let ulid1 = ULID(timestamp: timestamp)
+        let ulid2 = ULID(timestamp: timestamp)
+
+        XCTAssertNotEqual(ulid1.hashValue, ulid2.hashValue)
+    }
+
+    func testHashable3() {
+        let ulid1 = ULID()
+        let ulid2 = ULID()
+        let map = [ulid1: 1, ulid2: 2]
+
+        XCTAssertEqual(1, map[ulid1]!)
+        XCTAssertEqual(2, map[ulid2]!)
+    }
+
+    func testEquatable1() {
+        let timestamp = Date(timeIntervalSince1970: 1547213173.513)
+
+        let ulid1 = ULID(timestamp: timestamp)
+        let ulid2 = ULID(ulid: ulid1.ulid)
+
+        XCTAssertEqual(ulid1, ulid2)
+    }
+
+    func testEquatable2() {
+        let timestamp = Date(timeIntervalSince1970: 1547213173.513)
+
+        let ulid1 = ULID(timestamp: timestamp)
+        let ulid2 = ULID(timestamp: timestamp)
+
+        XCTAssertNotEqual(ulid1, ulid2)
+    }
+
+    func testComparable1() {
+        let lhs = ULID(ulid: (1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        let rhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        XCTAssertFalse(lhs < rhs)
+        XCTAssertTrue(lhs > rhs)
+    }
+
+    func testComparable2() {
+        let lhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+        let rhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        XCTAssertFalse(lhs < rhs)
+        XCTAssertTrue(lhs > rhs)
+    }
+
+    func testComparable3() {
+        let lhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        let rhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+        XCTAssertTrue(lhs < rhs)
+        XCTAssertFalse(lhs > rhs)
+    }
+
+    func testComparable4() {
+        let now = Date()
+        let ulid0 = ULID(timestamp: now.addingTimeInterval(-120))
+        let ulid1 = ULID(timestamp: now.addingTimeInterval(-60))
+        let ulid2 = ULID(timestamp: now)
+        let ulid3 = ULID(timestamp: now.addingTimeInterval(60))
+        let ulid4 = ULID(timestamp: now.addingTimeInterval(120))
+        let sorted = [ulid2, ulid0, ulid3, ulid4, ulid1].sorted()
+
+        XCTAssertEqual(ulid0, sorted[0])
+        XCTAssertEqual(ulid1, sorted[1])
+        XCTAssertEqual(ulid2, sorted[2])
+        XCTAssertEqual(ulid3, sorted[3])
+        XCTAssertEqual(ulid4, sorted[4])
+    }
+
+    func testCustomStringConvertible() {
+        let ulid = ULID()
+        XCTAssertEqual(ulid.ulidString, ulid.description)
+    }
+
+    struct CodableModel: Codable {
+        let ulid: ULID
+    }
+
+    func testDecodable() {
+        let ulidString = "01D0YHEWR9WMPY4NNTPK1MR1TQ"
+        let json = """
+            { "ulid" : "\(ulidString)" }
+            """
+        do {
+            let decoder = JSONDecoder()
+            let model = try decoder.decode(CodableModel.self, from: json.data(using: .utf8)!)
+            XCTAssertEqual(ulidString, model.ulid.ulidString)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testDecodableError() {
+        let json = """
+            { "ulid" : "" }
+            """
+        do {
+            let decoder = JSONDecoder()
+            _ = try decoder.decode(CodableModel.self, from: json.data(using: .utf8)!)
+            XCTFail()
+        } catch DecodingError.dataCorrupted {
+            // Success
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testEncodable() {
+        let ulidString = "01D0YHEWR9WMPY4NNTPK1MR1TQ"
+        let expected = """
+            {"ulid":"\(ulidString)"}
+            """
+        do {
+            let encoder = JSONEncoder()
+            let model = CodableModel(ulid: ULID(ulidString: ulidString)!)
+            let actual = try String(data: encoder.encode(model), encoding: .utf8)
+            XCTAssertEqual(expected, actual)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testMemorySize() {
+        XCTAssertEqual(16, MemoryLayout<ULID>.size)
+    }
+
+}
+
+extension ULID {
+    // If the ULID does not conform to Sendable, this code will result in a build error.
+    static let testSendable = ULID()
+}
+
+private struct MockRandomNumberGenerator: RandomNumberGenerator {
+
+    let value: UInt64
+
+    mutating func next() -> UInt64 {
+        return value
+    }
+
+}
+#endif

--- a/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
+++ b/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
@@ -15,10 +15,6 @@ struct MigrationTests {
     func complexMigration() async throws {
         let dbPath = try prepareContainerLocation(name: "complexMigration")
         
-        logger.info(
-            "Complex migration test started with db location: \(dbPath)"
-        )
-        
         let container = try ModelContainer(
             ComplexSchemaV0_0_1.self,
             migration: ComplexMigrationSuccess.self,

--- a/Tests/VeinTests/Migrations/FieldsAdded.swift
+++ b/Tests/VeinTests/Migrations/FieldsAdded.swift
@@ -9,10 +9,6 @@ extension MigrationTests {
     func fieldsAddedMigration() throws {
         let dbPath = try prepareContainerLocation(name: "fieldAddedMigration")
         
-        logger.info(
-            "Field added migration test started with db location: \(dbPath)"
-        )
-        
         let container = try ModelContainer(
             SimpleSchemaV0_0_3.self,
             migration: SimpleMigration.self,

--- a/Tests/VeinTests/Migrations/Unchanged+Delete.swift
+++ b/Tests/VeinTests/Migrations/Unchanged+Delete.swift
@@ -9,10 +9,6 @@ extension MigrationTests {
     func simpleMigration() throws {
         let dbPath = try prepareContainerLocation(name: "simpleMigration")
         
-        logger.info(
-            "Simple migration test started with db location: \(dbPath)"
-        )
-        
         let container = try ModelContainer(
             SimpleSchemaV0_0_1.self,
             migration: SimpleMigrationSuccess.self,

--- a/Tests/VeinTests/Multithread/MultithreadedTest.swift
+++ b/Tests/VeinTests/Multithread/MultithreadedTest.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import VeinTesting
+import Vein
+import VeinCore
+
+@MainActor
+struct MultithreadedTest {
+    @Test
+    func run() async throws {
+        let container = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<100 {
+                group.addTask {
+                    // 1. Write an object
+                    let model = Version1.Task(name: "Task \(i)")
+                    try! container.context.insert(model)
+                    try! container.context.save()
+                    
+                    _ = try! container.context.fetchAll(Version1.Task.self)
+                }
+            }
+        }
+        
+        // Assert all 100 records exist and matches expected count
+        let total = try container.context.fetchAll(Version1.Task.self).count
+        #expect(total == 100)
+    }
+}
+
+fileprivate enum Version1: VersionedSchema {
+    static let version = ModelVersion(1, 0, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        Task.self
+    ]}
+    
+    @Model
+    final class Task {
+        @Field var name: String
+        init(name: String) { self.name = name }
+    }
+}
+
+fileprivate enum MigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self
+    ]}
+    
+    static var stages: [Vein.MigrationStage] {[]}
+}
+

--- a/Tests/VeinTests/Multithread/MultithreadedTest.swift
+++ b/Tests/VeinTests/Multithread/MultithreadedTest.swift
@@ -4,7 +4,6 @@ import Testing
 import Vein
 import VeinCore
 
-@MainActor
 struct MultithreadedTest {
     @Test
     func run() async throws {
@@ -19,7 +18,7 @@ struct MultithreadedTest {
         await withTaskGroup(of: Void.self) { group in
             for i in 0..<100 {
                 group.addTask {
-                    // 1. Write an object
+                    try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
                     let model = Version1.Task(name: "Task \(i)")
                     try! container.context.insert(model)
                     try! container.context.save()
@@ -29,8 +28,7 @@ struct MultithreadedTest {
             }
         }
         
-        // Assert all 100 records exist and matches expected count
-        let total = try container.context.fetchAll(Version1.Task.self).count
+        let total = try! container.context.fetchAll(Version1.Task.self).count
         #expect(total == 100)
     }
 }

--- a/Tests/VeinTests/Multithread/MultithreadedTest.swift
+++ b/Tests/VeinTests/Multithread/MultithreadedTest.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import VeinTesting
+import Vein
+import VeinCore
+
+@MainActor
+struct MultithreadedTest {
+    @Test
+    func run() async throws {
+        let container = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<100 {
+                group.addTask {
+                    // 1. Write an object
+                    let model = Version1.Task(name: "Task \(i)")
+                    try? container.context.insert(model)
+                    try? container.context.save()
+                    
+                    let _ = try? container.context.fetchAll(Version1.Task.self)
+                }
+            }
+        }
+        
+        // Assert all 100 records exist and matches expected count
+        let total = try container.context.fetchAll(Version1.Task.self).count
+        #expect(total == 100)
+    }
+}
+
+fileprivate enum Version1: VersionedSchema {
+    static let version = ModelVersion(1, 0, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        Task.self
+    ]}
+    
+    @Model
+    final class Task {
+        @Field var name: String
+        init(name: String) { self.name = name }
+    }
+}
+
+fileprivate enum MigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self
+    ]}
+    
+    static var stages: [Vein.MigrationStage] {[]}
+}
+

--- a/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
@@ -11,10 +11,6 @@ import Logging
     @Test func testPersist() async throws {
         let dbPath = try prepareContainerLocation(name: "RelationshipMigration")
         
-        Self.logger.info(
-            "Relationship migration test started with db location: \(dbPath)"
-        )
-        
         let container = try ModelContainer(
             V0_0_1.self,
             migration: Migration.self,
@@ -51,6 +47,7 @@ import Logging
             appID: "de.amethystsoft.vein.RelationshipTests",
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
+        
         try newContainer.migrate()
         
         let firstUser = try newContainer.context.fetchAll(V0_0_2.User.self).first
@@ -101,6 +98,7 @@ import Logging
             appID: "de.amethystsoft.vein.ManyToManyTests",
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
+        
         try newContainer.migrate()
         
         // 3. Verify Many-to-Many integrity on V3

--- a/Tests/VeinTests/Relationships/RelationshipUpdateTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipUpdateTest.swift
@@ -8,7 +8,7 @@ import Logging
 extension RelationshipTest {    
     @Test func testUpdate() async throws {
         let dbPath = try prepareContainerLocation(name: "RelationshipUpdate")
-        Self.logger.info("started with database path: \(dbPath)")
+
         let container = try ModelContainer(
             V0_0_1.self,
             migration: Migration.self,

--- a/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
@@ -10,10 +10,6 @@ extension RelationshipTest {
     func testDeleteCascade() async throws {
         let dbPath = try prepareContainerLocation(name: "DeleteCascade")
         
-        Self.logger.info(
-            "Relationship migration test started with db location: \(dbPath)"
-        )
-        
         let container = try ModelContainer(
             CommentRelationshipCascade.self,
             migration: CascadeMigration.self,
@@ -66,11 +62,7 @@ extension RelationshipTest {
     @Test(.timeLimit(.minutes(1)))
     func testDeleteCascadeCascade() async throws {
         let dbPath = try prepareContainerLocation(name: "DeleteCascadeCascade")
-        
-        Self.logger.info(
-            "Relationship migration test started with db location: \(dbPath)"
-        )
-        
+
         let container = try ModelContainer(
             RelationshipCascadeCascade.self,
             migration: CascadeCascadeMigration.self,
@@ -123,10 +115,6 @@ extension RelationshipTest {
     @Test(.timeLimit(.minutes(1)))
     func testDeleteNullify() async throws {
         let dbPath = try prepareContainerLocation(name: "DeleteNullify")
-        
-        Self.logger.info(
-            "Relationship migration test started with db location: \(dbPath)"
-        )
         
         let container = try ModelContainer(
             CommentRelationshipNullify.self,

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,0 +1,1 @@
+race:sqlite3.c


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds Thread Sanitizer (TSAN) testing support and integrates the ULID library directly into the vein package, along with fixes to a ULID init that was flagged by the sanitizer.

### Key Changes

**Thread Sanitizer Implementation**
- Created `Scripts/tsan-test.sh` to run tests under TSAN with `--sanitize=thread` flag and Thread Sanitizer suppressions
- Updated CI workflows (`.github/workflows/swift-test-linux.yml` and `swift-test-mac.yml`) to execute the new TSAN script instead of standard `swift test`
- Added `tsan_suppressions.txt` to suppress known race conditions in SQLite (used by the data store)
- Created `Scripts/test.sh` for running standard tests with encryption disabled and experimental prebuilts enabled

**ULID Library Integration**
- Merged ULID library directly into the vein package by adding:
  - `Sources/ULID/ULID.swift`: Complete ULID implementation supporting timestamp-based generation, parsing from strings/raw data, Hashable/Equatable/Comparable protocols, Codable support, and Sendable semantics, copied from original package & modified one init.
  - `Sources/ULID/Data+Base32.swift`: Base32 encoding/decoding using Crockford's alphabet with proper padding handling, copied from original package
- Updated `Package.swift` to define local `ULID` target and `ULIDTests` test target, replacing external `ULID.swift` dependency
- Added comprehensive test suites validating Base32 operations and ULID functionality including round-trip encoding, ordering, and size constraints, copied from original package

**Test Logging Cleanup**
- Removed informational logging statements from multiple test files that were printing database locations:
  - Migration tests (`ComplexMigrationTests.swift`, `FieldsAdded.swift`, `Unchanged+Delete.swift`, `RelationshipMigrationTest.swift`)
  - Relationship tests (`RelationshipUpdateTest.swift`, `RelationshiptDeleteRuleTest.swift`)
- Updated `ManagedObjectContext+Relationship.swift` to emit warnings as info-level logs during migrations (reducing log noise)

**New Test Infrastructure**
- Added `MultithreadedTest.swift` to verify concurrent task insertion and retrieval, ensuring thread safety of the persistence layer

### Notable Quality Improvements

The commit message notes "0 warnings" - the modification of the ULID init resolved warnings detected by TSAN analysis. The comprehensive test coverage for the newly integrated ULID library (526 lines of tests for 434 lines of implementation) and the addition of multithreaded testing demonstrate strong quality assurance practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->