### PR TITLE
Fixed comment treated as part of type

### DIFF
--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 jobs:
   linux-android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
@@ -17,6 +17,6 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
-          swift-build-flags: --enable-experimental-prebuilts -Xswiftc -index-store-path -Xswiftc /tmp
+          swift-build-flags: --enable-experimental-prebuilts
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -9,12 +9,6 @@ jobs:
   linux-android:
     runs-on: ubuntu-24.04
     steps:
-      - name: Clean Build Cache
-        run: |
-          rm -rf .build/
-          rm -rf ~/.swiftpm/cache
-          rm -rf ~/.swiftpm/swift-sdks/.build
-          rm -rf ~/.cache/swiftpm
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
@@ -23,6 +17,6 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
-          swift-build-flags: --enable-experimental-prebuilts
+          swift-build-flags: --enable-experimental-prebuilts --disable-index-store
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           persist-credentials: false
       - name: "Test Swift Package on Android"
-        uses: skiptools/swift-android-action@8db781febb546110d48dee035131db8f4e259e91 # 2.9.4
+        uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
         with:
+          swift-version: 'nightly-main'
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
           test-env: SHOULD_DISABLE_ENCRYPTION=1
-          

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -13,6 +13,8 @@ jobs:
         run: |
           rm -rf .build/
           rm -rf ~/.swiftpm/cache
+          rm -rf ~/.swiftpm/swift-sdks/.build
+          rm -rf ~/.cache/swiftpm
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
-          swift-build-flags: --enable-experimental-prebuilts --disable-index-store
+          swift-build-flags: --enable-experimental-prebuilts -Xswiftc -index-store-path -Xswiftc /tmp
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
-          swift-build-flags: --enable-experimental-prebuilts --disable-index-store
+          swift-build-flags: --enable-experimental-prebuilts
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -9,6 +9,10 @@ jobs:
   linux-android:
     runs-on: ubuntu-24.04
     steps:
+      - name: Clean Build Cache
+        run: |
+          rm -rf .build/
+          rm -rf ~/.swiftpm/cache
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -17,6 +17,5 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
-          swift-build-flags: --enable-experimental-prebuilts
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
-          swift-build-flags: --enable-experimental-prebuilts
+          swift-build-flags: --enable-experimental-prebuilts --disable-index-store
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           

--- a/Package.swift
+++ b/Package.swift
@@ -119,9 +119,12 @@ let package = Package(
             dependencies: [
                 "Vein",
                 "VeinCore",
+                "VeinCoreMacros",
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SQLiteDB", package: "swift-sqlcipher"),
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax")
             ]
         ),
         .testTarget(
@@ -130,9 +133,6 @@ let package = Package(
                 "VeinTesting",
                 "Vein",
                 "VeinCore",
-                "VeinCoreMacros",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "Logging", package: "swift-log")
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -124,6 +124,7 @@ let package = Package(
                 "VeinCore",
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SQLiteDB", package: "swift-sqlcipher"),
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
             ]
         ),
         .testTarget(
@@ -132,6 +133,9 @@ let package = Package(
                 "VeinTesting",
                 "Vein",
                 "VeinCore",
+                "VeinCoreMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "Logging", package: "swift-log")
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,89 @@ var veinDependencies: [Target.Dependency] = [
     )
 ]
 
+var targets: [Target] = [
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
+    .target(
+        name: "Vein",
+        dependencies: veinDependencies
+    ),
+    .target(
+        name: "VeinCore",
+        dependencies: [
+            "Vein",
+            "VeinCoreMacros",
+        ]
+    ),
+    .target(
+        name: "VeinSwiftUI",
+        dependencies: [
+            "Vein",
+            "VeinSwiftUIMacros"
+        ]
+    ),
+    .target(
+        name: "VeinTesting",
+        dependencies: [
+            "Vein"
+        ]
+    ),
+    .macro(
+        name: "VeinCoreMacros",
+        dependencies: [
+            .product(name: "SwiftSyntax", package: "swift-syntax"),
+            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
+        ]
+    ),
+    .macro(
+        name: "VeinSwiftUIMacros",
+        dependencies: [
+            .product(name: "SwiftSyntax", package: "swift-syntax"),
+            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
+        ]
+    ),
+    .target(
+        name: "VeinMacrosBaseWrapper",
+        dependencies: [
+            .product(name: "VeinMacrosCore", package: "VeinMacrosCore")
+        ],
+    ),
+    .target(name: "ULID"),
+    .testTarget(
+        name: "VeinTests",
+        dependencies: [
+            "Vein",
+            "VeinCore",
+            .product(name: "Logging", package: "swift-log"),
+            .product(name: "SQLiteDB", package: "swift-sqlcipher"),
+            .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+        ]
+    ),
+    .testTarget(
+        name: "VeinTestingTests",
+        dependencies: [
+            "VeinTesting",
+            "Vein",
+            "VeinCore",
+            "VeinCoreMacros",
+            .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+            .product(name: "Logging", package: "swift-log")
+        ]
+    ),
+]
+#if os(macOS)
+targets.append(
+    .testTarget(
+        name: "ULIDTests",
+        dependencies: ["ULID"]
+    )
+)
+#endif
 
 let package = Package(
     name: "amethyst-vein",
@@ -55,93 +138,15 @@ let package = Package(
         .package(path: "./VeinMacrosCore"),
         // SQLite >= 3.45.0 is required to support JSONB.
         // The bundled version of swift-sqlcipher >= 1.9.0 matches that requirement.
-        .package(
-            url: "https://github.com/skiptools/swift-sqlcipher",
-            .upToNextMajor(from: "1.9.0")
-        ),
+            .package(
+                url: "https://github.com/skiptools/swift-sqlcipher",
+                .upToNextMajor(from: "1.9.0")
+            ),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "610.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.9.1")),
         .package(url: "https://github.com/kishikawakatsumi/keychainaccess", .upToNextMajor(from: "4.2.2")),
         .package(url: "https://github.com/amethystsoft/KeyringAccess", .upToNextMajor(from: "1.0.0")),
     ],
-    targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
-        .target(
-            name: "Vein",
-            dependencies: veinDependencies
-        ),
-        .target(
-            name: "VeinCore",
-            dependencies: [
-                "Vein",
-                "VeinCoreMacros",
-            ]
-        ),
-        .target(
-            name: "VeinSwiftUI",
-            dependencies: [
-                "Vein",
-                "VeinSwiftUIMacros"
-            ]
-        ),
-        .target(
-            name: "VeinTesting",
-            dependencies: [
-                "Vein"
-            ]
-        ),
-        .macro(
-            name: "VeinCoreMacros",
-            dependencies: [
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-                .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
-            ]
-        ),
-        .macro(
-            name: "VeinSwiftUIMacros",
-            dependencies: [
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-                .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
-            ]
-        ),
-        .target(
-            name: "VeinMacrosBaseWrapper",
-            dependencies: [
-                .product(name: "VeinMacrosCore", package: "VeinMacrosCore")
-            ],
-        ),
-        .target(name: "ULID"),
-        .testTarget(
-            name: "VeinTests",
-            dependencies: [
-                "Vein",
-                "VeinCore",
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "SQLiteDB", package: "swift-sqlcipher"),
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-            ]
-        ),
-        .testTarget(
-            name: "VeinTestingTests",
-            dependencies: [
-                "VeinTesting",
-                "Vein",
-                "VeinCore",
-                "VeinCoreMacros",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "Logging", package: "swift-log")
-            ]
-        ),
-        .testTarget(
-            name: "ULIDTests",
-            dependencies: ["ULID"]
-        )
-    ]
+    targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -21,90 +21,6 @@ var veinDependencies: [Target.Dependency] = [
     )
 ]
 
-var targets: [Target] = [
-    // Targets are the basic building blocks of a package, defining a module or a test suite.
-    // Targets can depend on other targets in this package and products from dependencies.
-    .target(
-        name: "Vein",
-        dependencies: veinDependencies
-    ),
-    .target(
-        name: "VeinCore",
-        dependencies: [
-            "Vein",
-            "VeinCoreMacros",
-        ]
-    ),
-    .target(
-        name: "VeinSwiftUI",
-        dependencies: [
-            "Vein",
-            "VeinSwiftUIMacros"
-        ]
-    ),
-    .target(
-        name: "VeinTesting",
-        dependencies: [
-            "Vein"
-        ]
-    ),
-    .macro(
-        name: "VeinCoreMacros",
-        dependencies: [
-            .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-            .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
-        ]
-    ),
-    .macro(
-        name: "VeinSwiftUIMacros",
-        dependencies: [
-            .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-            .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
-        ]
-    ),
-    .target(
-        name: "VeinMacrosBaseWrapper",
-        dependencies: [
-            .product(name: "VeinMacrosCore", package: "VeinMacrosCore")
-        ],
-    ),
-    .target(name: "ULID"),
-    .testTarget(
-        name: "VeinTests",
-        dependencies: [
-            "Vein",
-            "VeinCore",
-            .product(name: "Logging", package: "swift-log"),
-            .product(name: "SQLiteDB", package: "swift-sqlcipher"),
-            .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-        ]
-    ),
-    .testTarget(
-        name: "VeinTestingTests",
-        dependencies: [
-            "VeinTesting",
-            "Vein",
-            "VeinCore",
-            "VeinCoreMacros",
-            .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-            .product(name: "Logging", package: "swift-log")
-        ]
-    ),
-]
-#if os(macOS)
-targets.append(
-    .testTarget(
-        name: "ULIDTests",
-        dependencies: ["ULID"]
-    )
-)
-#endif
-
 let package = Package(
     name: "amethyst-vein",
     platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v17), .macCatalyst(.v17), .visionOS(.v1)],
@@ -148,5 +64,81 @@ let package = Package(
         .package(url: "https://github.com/kishikawakatsumi/keychainaccess", .upToNextMajor(from: "4.2.2")),
         .package(url: "https://github.com/amethystsoft/KeyringAccess", .upToNextMajor(from: "1.0.0")),
     ],
-    targets: targets
+    targets: [
+        .target(
+            name: "Vein",
+            dependencies: veinDependencies
+        ),
+        .target(
+            name: "VeinCore",
+            dependencies: [
+                "Vein",
+                "VeinCoreMacros",
+            ]
+        ),
+        .target(
+            name: "VeinSwiftUI",
+            dependencies: [
+                "Vein",
+                "VeinSwiftUIMacros"
+            ]
+        ),
+        .target(
+            name: "VeinTesting",
+            dependencies: [
+                "Vein"
+            ]
+        ),
+        .macro(
+            name: "VeinCoreMacros",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
+            ]
+        ),
+        .macro(
+            name: "VeinSwiftUIMacros",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "VeinMacrosCore", package: "VeinMacrosCore"),
+            ]
+        ),
+        .target(
+            name: "VeinMacrosBaseWrapper",
+            dependencies: [
+                .product(name: "VeinMacrosCore", package: "VeinMacrosCore")
+            ],
+        ),
+        .target(name: "ULID"),
+        .testTarget(
+            name: "VeinTests",
+            dependencies: [
+                "Vein",
+                "VeinCore",
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "SQLiteDB", package: "swift-sqlcipher"),
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+            ]
+        ),
+        .testTarget(
+            name: "VeinTestingTests",
+            dependencies: [
+                "VeinTesting",
+                "Vein",
+                "VeinCore",
+                "VeinCoreMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "Logging", package: "swift-log")
+            ]
+        ),
+        .testTarget(
+            name: "ULIDTests",
+            dependencies: ["ULID"]
+        )
+    ]
 )

--- a/Tests/ULIDTests/Data+Base32Tests.swift
+++ b/Tests/ULIDTests/Data+Base32Tests.swift
@@ -5,6 +5,7 @@
 //  Created by Yasuhiro Hatta on 2019/01/12.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
+#if !os(Android)
 import XCTest
 @testable import ULID
 
@@ -224,3 +225,4 @@ final class Base32Tests: XCTestCase {
     }
 
 }
+#endif

--- a/Tests/ULIDTests/Data+Base32Tests.swift
+++ b/Tests/ULIDTests/Data+Base32Tests.swift
@@ -5,7 +5,6 @@
 //  Created by Yasuhiro Hatta on 2019/01/12.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
-#if os(macOS)
 import XCTest
 @testable import ULID
 
@@ -225,4 +224,3 @@ final class Base32Tests: XCTestCase {
     }
 
 }
-#endif

--- a/Tests/ULIDTests/ULIDTests.swift
+++ b/Tests/ULIDTests/ULIDTests.swift
@@ -5,7 +5,6 @@
 //  Created by Yasuhiro Hatta on 2019/01/11.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
-#if os(macOS)
 import XCTest
 import ULID
 
@@ -295,4 +294,3 @@ private struct MockRandomNumberGenerator: RandomNumberGenerator {
     }
 
 }
-#endif

--- a/Tests/ULIDTests/ULIDTests.swift
+++ b/Tests/ULIDTests/ULIDTests.swift
@@ -5,6 +5,7 @@
 //  Created by Yasuhiro Hatta on 2019/01/11.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
+#if !os(Android)
 import XCTest
 import ULID
 
@@ -294,3 +295,4 @@ private struct MockRandomNumberGenerator: RandomNumberGenerator {
     }
 
 }
+#endif

--- a/Tests/VeinTestingTests/StepByStep.swift
+++ b/Tests/VeinTestingTests/StepByStep.swift
@@ -8,11 +8,6 @@ import VeinCore
 struct StepByStep {
     @Test
     func stepByStepVerification() async throws {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
         let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
         
         let username = "miakoring"

--- a/Tests/VeinTestingTests/StepByStep.swift
+++ b/Tests/VeinTestingTests/StepByStep.swift
@@ -9,10 +9,8 @@ struct StepByStep {
     @Test
     func stepByStepVerification() async throws {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
 #endif
         let tester = try MigrationTester(migrationPlan: MigrationPlan.self)

--- a/Tests/VeinTestingTests/StepByStep.swift
+++ b/Tests/VeinTestingTests/StepByStep.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import VeinTesting
 import Vein
@@ -8,8 +9,10 @@ struct StepByStep {
     @Test
     func stepByStepVerification() async throws {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         let tester = try MigrationTester(migrationPlan: MigrationPlan.self)

--- a/Tests/VeinTestingTests/TestWholeChain.swift
+++ b/Tests/VeinTestingTests/TestWholeChain.swift
@@ -7,13 +7,7 @@ import VeinCore
 @MainActor
 struct WholeChain {
     @Test
-    func wholeChainMigration() async throws {
-#if os(Linux)
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
-#endif
-        
+    func wholeChainMigration() async throws {        
         let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
         
         let username = "miakoring"

--- a/Tests/VeinTestingTests/TestWholeChain.swift
+++ b/Tests/VeinTestingTests/TestWholeChain.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import VeinTesting
 import Vein
@@ -8,8 +9,10 @@ struct WholeChain {
     @Test
     func wholeChainMigration() async throws {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         

--- a/Tests/VeinTestingTests/TestWholeChain.swift
+++ b/Tests/VeinTestingTests/TestWholeChain.swift
@@ -9,11 +9,9 @@ struct WholeChain {
     @Test
     func wholeChainMigration() async throws {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
             Keyring.appIdentifier.withLock { identifier in
                 identifier = "de.amethystsoft.vein.tests"
             }
-        }
 #endif
         
         let tester = try MigrationTester(migrationPlan: MigrationPlan.self)

--- a/Tests/VeinTests/Bugs/GetByID.swift
+++ b/Tests/VeinTests/Bugs/GetByID.swift
@@ -4,7 +4,11 @@ import Logging
 import SQLiteDB
 @testable import Vein
 @testable import VeinCore
-
+#if canImport(Linux)
+let globalInit: Void = {
+    _ = Keyring.appIdentifier
+}()
+#endif
 @Suite
 struct BugTests {
     @Test

--- a/Tests/VeinTests/Bugs/GetByID.swift
+++ b/Tests/VeinTests/Bugs/GetByID.swift
@@ -4,7 +4,7 @@ import Logging
 import SQLiteDB
 @testable import Vein
 @testable import VeinCore
-#if canImport(Linux)
+#if os(Linux)
 let globalInit: Void = {
     _ = Keyring.appIdentifier
 }()

--- a/Tests/VeinTests/Bugs/GetByID.swift
+++ b/Tests/VeinTests/Bugs/GetByID.swift
@@ -4,11 +4,6 @@ import Logging
 import SQLiteDB
 @testable import Vein
 @testable import VeinCore
-#if os(Linux)
-let globalInit: Void = {
-    _ = Keyring.appIdentifier
-}()
-#endif
 @Suite
 struct BugTests {
     @Test

--- a/Tests/VeinTests/Context/ModelUsageConstraints.swift
+++ b/Tests/VeinTests/Context/ModelUsageConstraints.swift
@@ -8,8 +8,10 @@ import Testing
 struct ModelUsageConstraints {
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         

--- a/Tests/VeinTests/Context/ModelUsageConstraints.swift
+++ b/Tests/VeinTests/Context/ModelUsageConstraints.swift
@@ -8,10 +8,8 @@ import Testing
 struct ModelUsageConstraints {
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
 #endif
         

--- a/Tests/VeinTests/Context/ModelUsageConstraints.swift
+++ b/Tests/VeinTests/Context/ModelUsageConstraints.swift
@@ -6,13 +6,7 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ModelUsageConstraints {
-    func prepareContainerLocation(name: String) throws -> String {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
-        
+    func prepareContainerLocation(name: String) throws -> String {       
         let containerPath = FileManager.default.temporaryDirectory
         
         let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")

--- a/Tests/VeinTests/Context/TestWriteCache.swift
+++ b/Tests/VeinTests/Context/TestWriteCache.swift
@@ -9,8 +9,10 @@ struct WriteCache {
     
     private func setupContainer() throws -> ModelContainer {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         

--- a/Tests/VeinTests/Context/TestWriteCache.swift
+++ b/Tests/VeinTests/Context/TestWriteCache.swift
@@ -9,10 +9,8 @@ struct WriteCache {
     
     private func setupContainer() throws -> ModelContainer {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
 #endif
         

--- a/Tests/VeinTests/Context/TestWriteCache.swift
+++ b/Tests/VeinTests/Context/TestWriteCache.swift
@@ -8,12 +8,6 @@ import Testing
 struct WriteCache {
     
     private func setupContainer() throws -> ModelContainer {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
-        
         let container = try ModelContainer(
             V0_0_1.self,
             migration: Migration.self,

--- a/Tests/VeinTests/GlobalSetup.swift
+++ b/Tests/VeinTests/GlobalSetup.swift
@@ -1,0 +1,8 @@
+import Vein
+#if os(Linux)
+let globalInit: Void = {
+    Keyring.appIdentifier.withLock { identifier in
+        identifier = "de.amethystsoft.vein.tests"
+    }
+}()
+#endif

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import SwiftSyntaxMacrosGenericTestSupport
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+import VeinCoreMacros
+
+fileprivate let testMacros: [String: MacroSpec] = [
+    "Model": MacroSpec(type: ModelMacro.self)
+]
+
+@Suite
+struct MacrosTests {
+    @Test
+    func commentsAreNotTreatedAsPartOfType() async throws {
+        assertMacroExpansion(
+            """
+            @Model
+            final class Test {
+                @Field
+                var test: String // Test
+            }
+            """,
+            expandedSource: """
+            final class Test {
+                @Field
+                var test: String // Test
+            
+                /// The primary ID of the object.
+                /// Gets  used to reference models in relationships.
+                /// Immutable after insertion into the context.
+                @Vein.PrimaryKey
+                var id: Vein.ULID
+            
+                required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
+                    self.id = id
+                    self.test = try! String.init(
+                        fromPersistent: String.PersistentRepresentation.decode(
+                            sqliteValue: fields["test"]!
+                        )
+                    )!
+                    
+                    _setupFields()
+                }
+            
+                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+            
+                /// Sets required properties for @Field values.
+                /// Gets generated automatically by @Model.
+                public func _setupFields() {
+                    self._test.model = self
+                    self._test.key = "test"
+                    self._id.model = self
+                }
+            
+                var context: Vein.ManagedObjectContext? = nil
+            
+                /// Whether a model is prepared to be deleted.
+                ///
+                /// Reading this variable is safe, but it should never be set outside of Vein.
+                var _isPreparedForDeletion = false
+            
+                var _fields: [any Vein.FieldBase] {
+                    [
+                        self._id,
+                        self._test
+                    ]
+                }
+            
+                var _relationships: [any Vein.PersistedRelationship] {
+                    [
+                        
+                    ]
+                }
+            
+                static let _inverseFields = {
+                    var map = [ObjectIdentifier: [String: String]]()
+                    
+                    return map
+                }()
+            
+                static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
+                    switch keyPath {
+                        case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                        case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
+                        default: nil
+                    }
+                }
+            
+                static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                ]
+            
+                var notifyOfChanges: () -> Void {
+                    return {
+                    }
+                }
+            }
+            
+            extension Test: Vein.PersistentModel, @unchecked Sendable {
+                static let schema = "Test"
+                static var version: Vein.ModelVersion {
+                    Test.version
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: { spec in
+                Issue.record("\(spec.message)")
+            }
+        )
+    }
+}
+

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -1,3 +1,4 @@
+#if !os(Android)
 import Testing
 import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacros
@@ -110,4 +111,4 @@ struct MacrosTests {
         )
     }
 }
-
+#endif

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -1,4 +1,3 @@
-#if !os(Android)
 import Testing
 import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacros
@@ -111,4 +110,3 @@ struct MacrosTests {
         )
     }
 }
-#endif

--- a/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
+++ b/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
@@ -69,8 +69,10 @@ struct MigrationTests {
     
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         

--- a/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
+++ b/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
@@ -69,10 +69,8 @@ struct MigrationTests {
     
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
 #endif
         

--- a/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
+++ b/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
@@ -68,12 +68,6 @@ struct MigrationTests {
     }
     
     func prepareContainerLocation(name: String) throws -> String {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
-        
         let containerPath = FileManager.default.temporaryDirectory
         
         let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")

--- a/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
+++ b/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
@@ -8,10 +8,8 @@ import Logging
 struct RealDatabasePredicateTests {
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
 #endif
         

--- a/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
+++ b/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
@@ -6,13 +6,7 @@ import Logging
 
 @Suite
 struct RealDatabasePredicateTests {
-    func prepareContainerLocation(name: String) throws -> String {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
-        
+    func prepareContainerLocation(name: String) throws -> String {        
         let containerPath = FileManager.default.temporaryDirectory
         
         let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")

--- a/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
+++ b/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
@@ -8,8 +8,10 @@ import Logging
 struct RealDatabasePredicateTests {
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         

--- a/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
@@ -127,12 +127,6 @@ import Logging
     }
     
     func prepareContainerLocation(name: String) throws -> String {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
-        
         let containerPath = FileManager.default.temporaryDirectory
         
         let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")

--- a/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
@@ -128,8 +128,10 @@ import Logging
     
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
+        if ProcessInfo.shouldEnableEncryption {
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         }
 #endif
         

--- a/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
@@ -128,10 +128,8 @@ import Logging
     
     func prepareContainerLocation(name: String) throws -> String {
 #if os(Linux)
-        if ProcessInfo.shouldEnableEncryption {
-            Keyring.appIdentifier.withLock { identifier in
-                identifier = "de.amethystsoft.vein.tests"
-            }
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
 #endif
         

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -163,7 +163,6 @@ var _relationships: [any Vein.PersistedRelationship] {
 static let _inverseFields = {
     var map = [ObjectIdentifier: [String: String]]()
     \(inverseFieldData)
-    
     return map
 }()
 
@@ -302,7 +301,7 @@ extension Array where Element == VariableDeclSyntax {
             guard let binding = varDecl.bindings.first else { continue }
             guard
                 let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
-                let datatype = binding.typeAnnotation?.description
+                let datatype = binding.typeAnnotation?.type.trimmedDescription
             else { continue }
             fields[name] = datatype
         }

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,2 +1,1 @@
 race:sqlite3.c
-race:KeyringAccess.appIdentifier

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,1 +1,2 @@
 race:sqlite3.c
+race:KeyringAccess.appIdentifier


### PR DESCRIPTION
Resolves https://github.com/amethystsoft/vein/issues/11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes issue `#11`, where inline comments placed after type definitions in field declarations were incorrectly included as part of the type name in generated code.

### The Problem
For a declaration like `@Field var category: String // Added field`, the macro expansion could incorrectly incorporate the comment into the type string, affecting both:
- the generated initializer (e.g., `self.category = ... try! String // Added field.init(...)`)
- `_fieldInformation` (e.g., `Vein.FieldInformation(String // Added field.sqliteTypeName, "category", ...)`)

### The Solution
The fix is in `VeinMacrosCore/Sources/ModelMacroBase.swift`: field type extraction now uses `binding.typeAnnotation?.type.trimmedDescription` instead of `binding.typeAnnotation?.description`. Using SwiftSyntax’s `trimmedDescription` produces a normalized type representation that avoids comment/whitespace contamination—so the macro stops generating malformed type strings at the source.

### Validation
A new async macro-expansion test, `commentsAreNotTreatedAsPartOfType`, was added to `Tests/VeinTests/Macros/MacrosTests.swift`. It registers the `Model` macro and asserts that a model containing a `@Field` with an inline comment expands into the expected generated code (including correct init/from-persistent decoding and field metadata), while using `failureHandler` to surface macro-spec issues.

### Additional Changes
- Updated `Package.swift` to include `VeinCoreMacros` and `swift-syntax` macro testing products for the `VeinTests` target.
- Android CI workflow updated (runner to `ubuntu-24.04`, action revision/inputs adjusted, including a new nightly-main Swift version).
- Test suite cleanup for portability and consistency:
  - Removed macOS-only guards in ULID tests.
  - Added `import Foundation` to several test files.
  - Consolidated/adjusted Linux keychain identifier setup by adding `Tests/VeinTests/GlobalSetup.swift` and removing scattered per-test `Keyring.appIdentifier` override blocks.
  - Minor formatting-only edits in a few test contexts.

### Highlight
This is exceptionally well-executed: the change leverages Swift’s AST/Syntax representation (`trimmedDescription`) to prevent comment leakage cleanly, avoiding fragile string post-processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->