### PR TITLE
Now autogenerates @Field if no other propertywrapper is applied

### DIFF
--- a/Tests/VeinTests/Context/TestWriteCache.swift
+++ b/Tests/VeinTests/Context/TestWriteCache.swift
@@ -6,7 +6,6 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct WriteCache {
-    
     private func setupContainer() throws -> ModelContainer {
         let container = try ModelContainer(
             V0_0_1.self,
@@ -283,14 +282,10 @@ fileprivate enum V0_0_2: VersionedSchema {
     
     @Model
     final class Test: Identifiable {
-        @Field
         var flag: Bool
-        
-        @Field
         var someValue: String
         
         // Renamed and transformed from randomValue
-        @Field
         var securityCode: String
         
         init(flag: Bool, someValue: String, securityCode: String) {

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -109,4 +109,103 @@ struct MacrosTests {
             }
         )
     }
+    
+    @Test
+    func fieldAutogenerationWorks() async throws {
+        assertMacroExpansion(
+            """
+            @Model
+            final class Test {
+                var test: String // Test
+            }
+            """,
+            expandedSource: """
+            final class Test {
+                @Vein.Field
+                var test: String // Test
+            
+                /// The primary ID of the object.
+                /// Gets  used to reference models in relationships.
+                /// Immutable after insertion into the context.
+                @Vein.PrimaryKey
+                var id: Vein.ULID
+            
+                required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
+                    self.id = id
+                    self.test = try! String.init(
+                        fromPersistent: String.PersistentRepresentation.decode(
+                            sqliteValue: fields["test"]!
+                        )
+                    )!
+                    
+                    _setupFields()
+                }
+            
+                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+            
+                /// Sets required properties for @Field values.
+                /// Gets generated automatically by @Model.
+                public func _setupFields() {
+                    self._test.model = self
+                    self._test.key = "test"
+                    self._id.model = self
+                }
+            
+                var context: Vein.ManagedObjectContext? = nil
+            
+                /// Whether a model is prepared to be deleted.
+                ///
+                /// Reading this variable is safe, but it should never be set outside of Vein.
+                var _isPreparedForDeletion = false
+            
+                var _fields: [any Vein.FieldBase] {
+                    [
+                        self._id,
+                        self._test
+                    ]
+                }
+            
+                var _relationships: [any Vein.PersistedRelationship] {
+                    [
+                        
+                    ]
+                }
+            
+                static let _inverseFields = {
+                    var map = [ObjectIdentifier: [String: String]]()
+                    
+                    return map
+                }()
+            
+                static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
+                    switch keyPath {
+                        case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                        case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
+                        default: nil
+                    }
+                }
+            
+                static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                ]
+            
+                var notifyOfChanges: () -> Void {
+                    return {
+                    }
+                }
+            }
+            
+            extension Test: Vein.PersistentModel, @unchecked Sendable {
+                static let schema = "Test"
+                static var version: Vein.ModelVersion {
+                    Test.version
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: { spec in
+                Issue.record("\(spec.message)")
+            }
+        )
+    }
 }

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -353,7 +353,8 @@ extension Dictionary where Key == String, Value == String {
 
 extension VariableDeclSyntax {
     var isPlainInstanceField: Bool {
-        bindings.count == 1
+        bindingSpecifier.trimmedDescription == "var"
+        && bindings.count == 1
         && bindings.first?.accessorBlock == nil
         && !modifiers.contains(where: { $0.name.text == "static" || $0.name.text == "class" })
     }

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -206,6 +206,13 @@ static let _fieldInformation: [Vein.FieldInformation] = [
     ) throws -> [AttributeSyntax] {
         // Find the marker @Relationship attribute on the property
         guard let relationshipAttr = findRelationshipAttribute(in: varDecl) else {
+            guard varDecl.isPlainInstanceField else { return [] }
+            if
+                FieldType.field.matches(varDecl, frameworkName: frameworkName),
+                !FieldType.field.matches(varDecl, frameworkName: frameworkName, checkNoFieldAttribute: false)
+            {
+                return ["@Vein.Field"]
+            }
             return []
         }
         
@@ -265,11 +272,18 @@ public enum FieldType {
 }
 
 extension FieldType {
-    func matches(_ variable: VariableDeclSyntax, frameworkName: String) -> Bool {
+    func matches(_ variable: VariableDeclSyntax, frameworkName: String, checkNoFieldAttribute: Bool = true) -> Bool {
+        let hasExplicitField = variable.hasAttributeOrMacro(named: "Field")
+            || variable.hasAttributeOrMacro(named: "\(frameworkName).Field")
+        
         return switch self {
             case .field:
-                variable.hasAttributeOrMacro(named: "Field")
-                || variable.hasAttributeOrMacro(named: "\(frameworkName).Field")
+                hasExplicitField || (
+                    checkNoFieldAttribute
+                    && variable.isPlainInstanceField
+                    && !FieldType.lazyField.matches(variable, frameworkName: frameworkName)
+                    && !FieldType.relationship.matches(variable, frameworkName: frameworkName)
+                )
             case .lazyField:
                 variable.hasAttributeOrMacro(named: "LazyField")
                 || variable.hasAttributeOrMacro(named: "\(frameworkName).LazyField")
@@ -338,6 +352,12 @@ extension Dictionary where Key == String, Value == String {
 }
 
 extension VariableDeclSyntax {
+    var isPlainInstanceField: Bool {
+        bindings.count == 1
+        && bindings.first?.accessorBlock == nil
+        && !modifiers.contains(where: { $0.name.text == "static" || $0.name.text == "class" })
+    }
+    
     func hasAttributeOrMacro(named name: String) -> Bool {
         let parts = name.split(separator: ".")
         


### PR DESCRIPTION
Resolves https://github.com/amethystsoft/vein/issues/37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds automatic `@Field` generation for plain model properties that don’t declare `@LazyField` or a relationship wrapper, while keeping `@Field` available for explicit use.

Also updates tests to cover the new default behavior and adjusts existing cache/schema test fixtures to reflect properties now being treated as implicit fields.

Nice improvement: this keeps Vein’s model declarations explicit, but makes the common eager-field case work without extra annotation noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->