### PR TITLE
Added LazyField tests and now runs the entire testsuite on VeinSwiftUI too

### DIFF
--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -13,5 +13,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
-      - name: Test macOS
+      - name: Test VeinCore
         run: ./Scripts/tsan-test.sh
+      - name: Test VeinSwiftUI
+        run: TEST_SWIFTUI=1 ./Scripts/tsan-test.sh

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,20 @@
 
 import PackageDescription
 import CompilerPluginSupport
+import Foundation
+
+#if os(macOS)
+let testSwiftUI = ProcessInfo.processInfo.environment["TEST_SWIFTUI"] != nil
+
+let veinAPIToTestDependencies: [Target.Dependency] = testSwiftUI ?
+    ["VeinSwiftUI", "VeinSwiftUIMacros"]:
+    ["VeinCore", "VeinCoreMacros"]
+
+let testSwiftSettings: [SwiftSetting] = testSwiftUI ? [.define("TEST_SWIFTUI")] : []
+#else
+let veinAPIToTestDependencies: [Target.Dependency] = ["VeinCore", "VeinCoreMacros"]
+let testSwiftSettings: [SwiftSetting] = []
+#endif
 
 var veinDependencies: [Target.Dependency] = [
     .product(name: "Crypto", package: "swift-crypto"),
@@ -48,7 +62,7 @@ let package = Package(
         .library(
             name: "ULID",
             targets: ["ULID"]
-        )
+        ),
     ],
     dependencies: [
         .package(path: "./VeinMacrosCore"),
@@ -118,23 +132,22 @@ let package = Package(
             name: "VeinTests",
             dependencies: [
                 "Vein",
-                "VeinCore",
-                "VeinCoreMacros",
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SQLiteDB", package: "swift-sqlcipher"),
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax")
-            ]
+            ] + veinAPIToTestDependencies,
+            swiftSettings: testSwiftSettings
         ),
         .testTarget(
             name: "VeinTestingTests",
             dependencies: [
                 "VeinTesting",
                 "Vein",
-                "VeinCore",
                 .product(name: "Logging", package: "swift-log")
-            ]
+            ] + veinAPIToTestDependencies,
+            swiftSettings: testSwiftSettings
         ),
         .testTarget(
             name: "ULIDTests",

--- a/Sources/Vein/Model/PropertyWrappers/Fields.swift
+++ b/Sources/Vein/Model/PropertyWrappers/Fields.swift
@@ -6,6 +6,9 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
     
     private let lock = NSLock()
     private var store: WrappedType
+    @_spi(VeinTesting) public var testingStoreSnapshot: WrappedType {
+        lock.withLock { store }
+    }
     private var readFromStore = false
     
     /// ONLY LET MACRO SET

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -9,9 +9,11 @@ import KeychainAccess
 @_exported import KeyringAccess
 #endif
 
+typealias Connection = SQLiteDB.Connection
+
 public actor ManagedObjectContext {
     public static let logger = Logger(label: "ManagedObjectContext")
-    package nonisolated let connection: Connection
+    package nonisolated let connection: SQLiteDB.Connection
     nonisolated unowned let modelContainer: ModelContainer
     
     // MARK: - Migrations

--- a/Sources/VeinSwiftUI/ModelMacro.swift
+++ b/Sources/VeinSwiftUI/ModelMacro.swift
@@ -1,5 +1,5 @@
 #if canImport(Combine)
-import Combine
+@_exported import Combine
 import Vein
 
 @attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation))

--- a/Tests/VeinTestingTests/StepByStep.swift
+++ b/Tests/VeinTestingTests/StepByStep.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 @testable import VeinTesting
 import Vein
+#if TEST_SWIFTUI
+import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 import VeinCore
+#endif
 
 @MainActor
 struct StepByStep {

--- a/Tests/VeinTestingTests/TestWholeChain.swift
+++ b/Tests/VeinTestingTests/TestWholeChain.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 @testable import VeinTesting
 import Vein
+#if TEST_SWIFTUI
+import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 import VeinCore
+#endif
 
 @MainActor
 struct WholeChain {

--- a/Tests/VeinTests/Bugs/GetByID.swift
+++ b/Tests/VeinTests/Bugs/GetByID.swift
@@ -3,7 +3,13 @@ import Testing
 import Logging
 import SQLiteDB
 @testable import Vein
+
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
+
 @Suite
 struct BugTests {
     @Test

--- a/Tests/VeinTests/Bugs/LazyJSONB.swift
+++ b/Tests/VeinTests/Bugs/LazyJSONB.swift
@@ -3,7 +3,12 @@ import Testing
 import Logging
 import SQLiteDB
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
+
 
 extension BugTests {
     @Test

--- a/Tests/VeinTests/Context/ModelUsageConstraints.swift
+++ b/Tests/VeinTests/Context/ModelUsageConstraints.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Testing
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @MainActor
 @Suite(.serialized)

--- a/Tests/VeinTests/Context/TestWriteCache.swift
+++ b/Tests/VeinTests/Context/TestWriteCache.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Testing
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @MainActor
 @Suite(.serialized)
@@ -98,6 +102,7 @@ struct WriteCache {
         
         // Test Insert Rollback
         let newModel = V0_0_1.Test(flag: true, someValue: "New", randomValue: 5)
+        newModel.text = "Test"
         try container.context.insert(newModel)
         container.context.rollback()
         #expect(newModel.context == nil)
@@ -105,13 +110,17 @@ struct WriteCache {
         
         // Test Update Rollback
         let existingModel = V0_0_1.Test(flag: false, someValue: "Original", randomValue: 100)
-        existingModel.context = container.context
-        existingModel._setupFields()
+        existingModel.text = "Test"
+        try container.context.insert(existingModel)
+        try container.context.save()
 
         existingModel.someValue = "Changed"
+        existingModel.text = "Updated"
+        
         
         container.context.rollback()
         #expect(existingModel.someValue == "Original")
+        #expect(existingModel.text == "Test")
         #expect(container.context.hasChanges == false)
         
         // Test Delete Rollback
@@ -267,6 +276,9 @@ fileprivate enum V0_0_1: VersionedSchema {
         
         @Field
         var randomValue: Int
+        
+        @LazyField
+        var text: String?
         
         init(flag: Bool, someValue: String, randomValue: Int) {
             self.flag = flag

--- a/Tests/VeinTests/FieldSpecificTests.swift
+++ b/Tests/VeinTests/FieldSpecificTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Vein
+#if TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinCore
+#endif
+
+@Suite
+struct FieldSpecificTests {
+    @Test
+    func testLazyFieldRetursStoreWithoutContext() async throws {
+        let field = LazyField(wrappedValue: "Test")
+        #expect(field.wrappedValue == "Test")
+    }
+    
+    @Test
+    func `@LazyField doesn't get fetched initially`() async throws {
+        let expectedText = "Wow, what a beautiful text that is"
+        let connection = try await prepareContainer()
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.fieldSpecific"
+        )
+        
+        guard let model = try container.context.fetchAll(V0_0_1.Test.self).first else {
+            Issue.record("Unexpectedly didn't find model")
+            return
+        }
+        
+        let lazyField = model.getLazyField()
+        
+        #expect(lazyField.testingStoreSnapshot.isNil)
+        #expect(model.text == expectedText)
+        #expect(lazyField.testingStoreSnapshot == expectedText)
+        
+        func prepareContainer() async throws -> Connection {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.fieldSpecific"
+            )
+            let model = V0_0_1.Test(someValue: "Test")
+            model.text = expectedText
+            try container.context.insert(model)
+            try container.context.save()
+            
+            return container.getConnection()
+        }
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self]
+    
+    @Model
+    final class Test: Identifiable {
+        var someValue: String
+        
+        @LazyField
+        var text: String?
+        
+        init(someValue: String) {
+            self.someValue = someValue
+        }
+        
+        func getLazyField() -> LazyField<String> {
+            _text
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -2,7 +2,11 @@ import Testing
 import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
-import VeinCoreMacros
+#if TEST_SWIFTUI
+@testable import VeinSwiftUIMacros
+#elseif !TEST_SWIFTUI
+@testable import VeinCoreMacros
+#endif
 
 fileprivate let testMacros: [String: MacroSpec] = [
     "Model": MacroSpec(type: ModelMacro.self)
@@ -12,6 +16,7 @@ fileprivate let testMacros: [String: MacroSpec] = [
 struct MacrosTests {
     @Test
     func commentsAreNotTreatedAsPartOfType() async throws {
+        #if !TEST_SWIFTUI
         assertMacroExpansion(
             """
             @Model
@@ -108,10 +113,120 @@ struct MacrosTests {
                 Issue.record("\(spec.message)")
             }
         )
+        #else
+        assertMacroExpansion(
+            """
+            @Model
+            final class Test {
+                @Field
+                var test: String // Test
+            }
+            """,
+            expandedSource: """
+            final class Test {
+                @Field
+                var test: String // Test
+            
+                /// The primary ID of the object.
+                /// Gets  used to reference models in relationships.
+                /// Immutable after insertion into the context.
+                @Vein.PrimaryKey
+                var id: Vein.ULID
+            
+                required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
+                    self.id = id
+                    self.test = try! String.init(
+                        fromPersistent: String.PersistentRepresentation.decode(
+                            sqliteValue: fields["test"]!
+                        )
+                    )!
+                    
+                    _setupFields()
+                }
+            
+                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+            
+                /// Sets required properties for @Field values.
+                /// Gets generated automatically by @Model.
+                public func _setupFields() {
+                    self._test.model = self
+                    self._test.key = "test"
+                    self._id.model = self
+                }
+            
+                var context: Vein.ManagedObjectContext? = nil
+            
+                /// Whether a model is prepared to be deleted.
+                ///
+                /// Reading this variable is safe, but it should never be set outside of Vein.
+                var _isPreparedForDeletion = false
+            
+                var _fields: [any Vein.FieldBase] {
+                    [
+                        self._id,
+                        self._test
+                    ]
+                }
+            
+                var _relationships: [any Vein.PersistedRelationship] {
+                    [
+                        
+                    ]
+                }
+            
+                static let _inverseFields = {
+                    var map = [ObjectIdentifier: [String: String]]()
+                    
+                    return map
+                }()
+            
+                static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
+                    switch keyPath {
+                        case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                        case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
+                        default: nil
+                    }
+                }
+            
+                static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                ]
+            
+                let objectWillChange = PassthroughSubject<Void, Never>()
+            
+                var notifyOfChanges: () -> Void {
+                    { [weak self] in
+                        guard let self else { return }
+                        for notification in self._observers.value.values {
+                            notification()
+                        }
+                        self.objectWillChange.send()
+                    }
+                }
+            }
+            
+            extension Test: Vein.PersistentModel, @unchecked Sendable {
+                static let schema = "Test"
+                static var version: Vein.ModelVersion {
+                    Test.version
+                }
+            }
+            
+            @MainActor
+            extension Test: ObservableObject {
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: { spec in
+                Issue.record("\(spec.message)")
+            }
+        )
+        #endif
     }
     
     @Test
     func fieldAutogenerationWorks() async throws {
+        #if !TEST_SWIFTUI
         assertMacroExpansion(
             """
             @Model
@@ -207,5 +322,113 @@ struct MacrosTests {
                 Issue.record("\(spec.message)")
             }
         )
+        #else
+        assertMacroExpansion(
+            """
+            @Model
+            final class Test {
+                var test: String // Test
+            }
+            """,
+            expandedSource: """
+            final class Test {
+                @Vein.Field
+                var test: String // Test
+            
+                /// The primary ID of the object.
+                /// Gets  used to reference models in relationships.
+                /// Immutable after insertion into the context.
+                @Vein.PrimaryKey
+                var id: Vein.ULID
+            
+                required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
+                    self.id = id
+                    self.test = try! String.init(
+                        fromPersistent: String.PersistentRepresentation.decode(
+                            sqliteValue: fields["test"]!
+                        )
+                    )!
+                    
+                    _setupFields()
+                }
+            
+                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+            
+                /// Sets required properties for @Field values.
+                /// Gets generated automatically by @Model.
+                public func _setupFields() {
+                    self._test.model = self
+                    self._test.key = "test"
+                    self._id.model = self
+                }
+            
+                var context: Vein.ManagedObjectContext? = nil
+            
+                /// Whether a model is prepared to be deleted.
+                ///
+                /// Reading this variable is safe, but it should never be set outside of Vein.
+                var _isPreparedForDeletion = false
+            
+                var _fields: [any Vein.FieldBase] {
+                    [
+                        self._id,
+                        self._test
+                    ]
+                }
+            
+                var _relationships: [any Vein.PersistedRelationship] {
+                    [
+                        
+                    ]
+                }
+            
+                static let _inverseFields = {
+                    var map = [ObjectIdentifier: [String: String]]()
+                    
+                    return map
+                }()
+            
+                static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
+                    switch keyPath {
+                        case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                        case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
+                        default: nil
+                    }
+                }
+            
+                static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String.sqliteTypeName, "test", true)
+                ]
+            
+                let objectWillChange = PassthroughSubject<Void, Never>()
+            
+                var notifyOfChanges: () -> Void {
+                    { [weak self] in
+                        guard let self else { return }
+                        for notification in self._observers.value.values {
+                            notification()
+                        }
+                        self.objectWillChange.send()
+                    }
+                }
+            }
+            
+            extension Test: Vein.PersistentModel, @unchecked Sendable {
+                static let schema = "Test"
+                static var version: Vein.ModelVersion {
+                    Test.version
+                }
+            }
+            
+            @MainActor
+            extension Test: ObservableObject {
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: { spec in
+                Issue.record("\(spec.message)")
+            }
+        )
+        #endif
     }
 }

--- a/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
+++ b/Tests/VeinTests/Migrations/ComplexMigrationTests.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 let testID = UUID()
 

--- a/Tests/VeinTests/Migrations/DetermineMigrationStage/NoMigrationForOutdatedModelVersion.swift
+++ b/Tests/VeinTests/Migrations/DetermineMigrationStage/NoMigrationForOutdatedModelVersion.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test func noMigrationForOutdatedModelVersion() async throws {

--- a/Tests/VeinTests/Migrations/DetermineMigrationStage/NoSchemaMatchingVersion.swift
+++ b/Tests/VeinTests/Migrations/DetermineMigrationStage/NoSchemaMatchingVersion.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test func throwsNoMatchingSchemaVersion() async throws {

--- a/Tests/VeinTests/Migrations/FieldsAdded.swift
+++ b/Tests/VeinTests/Migrations/FieldsAdded.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test

--- a/Tests/VeinTests/Migrations/ModelsUnhandledAfterMigration.swift
+++ b/Tests/VeinTests/Migrations/ModelsUnhandledAfterMigration.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test func modelsUnhandledAfterMigration() async throws {

--- a/Tests/VeinTests/Migrations/TestMigrationStoppingAtPassedVersion.swift
+++ b/Tests/VeinTests/Migrations/TestMigrationStoppingAtPassedVersion.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test func testMigrationStoppingAtPassedVersion() async throws {

--- a/Tests/VeinTests/Migrations/Unchanged+Delete.swift
+++ b/Tests/VeinTests/Migrations/Unchanged+Delete.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test

--- a/Tests/VeinTests/Migrations/VersionedSchemaIsNotPartOfSchemaMigrationPlan.swift
+++ b/Tests/VeinTests/Migrations/VersionedSchemaIsNotPartOfSchemaMigrationPlan.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension MigrationTests {
     @Test func versionedSchemaIsNotPartOfSchemaMigrationPlan() async throws {

--- a/Tests/VeinTests/ModelContainer/ModelContainerTests.swift
+++ b/Tests/VeinTests/ModelContainer/ModelContainerTests.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Testing
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @MainActor
 @Suite(.serialized)

--- a/Tests/VeinTests/Multithread/MultithreadedTest.swift
+++ b/Tests/VeinTests/Multithread/MultithreadedTest.swift
@@ -43,7 +43,7 @@ struct MultithreadedTest {
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
         
-        let tasks = try! newContainer.context.fetchAll(Version1.Task.self)
+        let tasks = try newContainer.context.fetchAll(Version1.Task.self)
         #expect(tasks.count == 100)
         #expect(tasks.allSatisfy { $0.text?.hasPrefix("Test ") == true })
     }
@@ -82,7 +82,7 @@ struct MultithreadedTest {
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
         
-        guard let result = try! newContainer.context.fetchAll(Version1.Task.self).first else {
+        guard let result = try newContainer.context.fetchAll(Version1.Task.self).first else {
             Issue.record("Unexpectedly no result for Version1.Task")
             return
         }
@@ -123,7 +123,7 @@ struct MultithreadedTest {
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
         
-        guard let result = try! newContainer.context.fetchAll(Version1.Task.self).first else {
+        guard let result = try newContainer.context.fetchAll(Version1.Task.self).first else {
             Issue.record("Unexpectedly no result for Version1.Task")
             return
         }

--- a/Tests/VeinTests/Multithread/MultithreadedTest.swift
+++ b/Tests/VeinTests/Multithread/MultithreadedTest.swift
@@ -19,18 +19,20 @@ struct MultithreadedTest {
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
         
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for i in 0..<100 {
                 group.addTask {
                     try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
                     let model = Version1.Task(name: "Task \(i)")
                     model.text = "Test \(i)"
-                    try! container.context.insert(model)
-                    try! container.context.save()
+                    try container.context.insert(model)
+                    try container.context.save()
                     
-                    _ = try! container.context.fetchAll(Version1.Task.self)
+                    _ = try container.context.fetchAll(Version1.Task.self)
                 }
             }
+            
+            try await group.waitForAll()
         }
         
         let newContainer = try ModelContainer(
@@ -59,15 +61,17 @@ struct MultithreadedTest {
         let model = Version1.Task(name: "Test")
         try container.context.insert(model)
         
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for i in 0..<100 {
                 group.addTask {
                     try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
                     _ = model.text
                     model.text = "Test \(i)"
-                    try! container.context.save()
+                    try container.context.save()
                 }
             }
+            
+            try await group.waitForAll()
         }
         
         let newContainer = try ModelContainer(
@@ -98,15 +102,17 @@ struct MultithreadedTest {
         let model = Version1.Task(name: "Base")
         try container.context.insert(model)
         
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for i in 0..<100 {
                 group.addTask {
                     try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
                     _ = model.name
                     model.name = "Test \(i)"
-                    try! container.context.save()
+                    try container.context.save()
                 }
             }
+            
+            try await group.waitForAll()
         }
         
         let newContainer = try ModelContainer(

--- a/Tests/VeinTests/Multithread/MultithreadedTest.swift
+++ b/Tests/VeinTests/Multithread/MultithreadedTest.swift
@@ -1,8 +1,12 @@
 import Foundation
 import Testing
 @testable import VeinTesting
-import Vein
-import VeinCore
+@testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@testable import VeinCore
+#endif
 
 struct MultithreadedTest {
     @Test
@@ -20,6 +24,7 @@ struct MultithreadedTest {
                 group.addTask {
                     try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
                     let model = Version1.Task(name: "Task \(i)")
+                    model.text = "Test \(i)"
                     try! container.context.insert(model)
                     try! container.context.save()
                     
@@ -28,8 +33,95 @@ struct MultithreadedTest {
             }
         }
         
-        let total = try! container.context.fetchAll(Version1.Task.self).count
-        #expect(total == 100)
+        let newContainer = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            connection: container.getConnection(),
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        let tasks = try! newContainer.context.fetchAll(Version1.Task.self)
+        #expect(tasks.count == 100)
+        #expect(tasks.allSatisfy { $0.text?.hasPrefix("Test ") == true })
+    }
+    
+    @Test
+    func multithreadedLazyFieldReadWrite() async throws {
+        let container = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        let model = Version1.Task(name: "Test")
+        try container.context.insert(model)
+        
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<100 {
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
+                    _ = model.text
+                    model.text = "Test \(i)"
+                    try! container.context.save()
+                }
+            }
+        }
+        
+        let newContainer = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            connection: container.getConnection(),
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        guard let result = try! newContainer.context.fetchAll(Version1.Task.self).first else {
+            Issue.record("Unexpectedly no result for Version1.Task")
+            return
+        }
+        #expect(result.text?.hasPrefix("Test ") == true)
+    }
+    
+    @Test
+    func multithreadedFieldReadWrite() async throws {
+        let container = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        let model = Version1.Task(name: "Base")
+        try container.context.insert(model)
+        
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<100 {
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: UInt64.random(in: 10_000...50_000))
+                    _ = model.name
+                    model.name = "Test \(i)"
+                    try! container.context.save()
+                }
+            }
+        }
+        
+        let newContainer = try ModelContainer(
+            Version1.self,
+            migration: MigrationPlan.self,
+            connection: container.getConnection(),
+            appID: "de.amethystsoft.vein.tests.multithreaded",
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+        )
+        
+        guard let result = try! newContainer.context.fetchAll(Version1.Task.self).first else {
+            Issue.record("Unexpectedly no result for Version1.Task")
+            return
+        }
+        #expect(result.name.hasPrefix("Test"))
     }
 }
 
@@ -42,6 +134,8 @@ fileprivate enum Version1: VersionedSchema {
     @Model
     final class Task {
         @Field var name: String
+        @LazyField var text: String?
+        
         init(name: String) { self.name = name }
     }
 }

--- a/Tests/VeinTests/Predicate/ModelLevelPredicate.swift
+++ b/Tests/VeinTests/Predicate/ModelLevelPredicate.swift
@@ -3,7 +3,11 @@ import Testing
 import Logging
 import SQLiteDB
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @Suite
 struct PredicateConversionTests {

--- a/Tests/VeinTests/Predicate/ModelLevelPredicatePersistableValue.swift
+++ b/Tests/VeinTests/Predicate/ModelLevelPredicatePersistableValue.swift
@@ -3,7 +3,11 @@ import Testing
 import Logging
 import SQLiteDB
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension PredicateConversionTests {
     @Test

--- a/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
+++ b/Tests/VeinTests/Predicate/PredicateOnDBTest.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @Suite
 struct RealDatabasePredicateTests {

--- a/Tests/VeinTests/Relationships/RelationshipManyManyTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipManyManyTest.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension RelationshipTest {
     // Example Schema: Tag (inverse: "posts") <-> Post (inverse: "tags")

--- a/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipMigrationTest.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @MainActor
 @Suite struct RelationshipTest {

--- a/Tests/VeinTests/Relationships/RelationshipSelfReferentialTree.swift
+++ b/Tests/VeinTests/Relationships/RelationshipSelfReferentialTree.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 extension RelationshipTest {
     @Test(.timeLimit(.minutes(1)))

--- a/Tests/VeinTests/Relationships/RelationshipUpdateTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshipUpdateTest.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @MainActor
 extension RelationshipTest {    

--- a/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
@@ -2,7 +2,11 @@ import Foundation
 import Testing
 import Logging
 @testable import Vein
+#if TEST_SWIFTUI
+@testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
 @testable import VeinCore
+#endif
 
 @MainActor
 extension RelationshipTest {

--- a/VeinPackageTests.xctestplan
+++ b/VeinPackageTests.xctestplan
@@ -1,0 +1,45 @@
+{
+  "configurations" : [
+    {
+      "id" : "F5294850-430D-46D7-BDA4-FED0C722FF02",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "SHOULD_DISABLE_ENCRYPTION",
+        "value" : "1"
+      }
+    ],
+    "testInteropMode" : "complete",
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "VeinTests",
+        "name" : "VeinTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "VeinTestingTests",
+        "name" : "VeinTestingTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ULIDTests",
+        "name" : "ULIDTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
resolves https://github.com/amethystsoft/vein/issues/16 in addition to other changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR expands test coverage around `LazyField` and makes the test suite run in both VeinCore and VeinSwiftUI modes.

Highlights:
- Added new `LazyField`-focused tests, including persistence, loading, rollback, and multithreaded behavior.
- Added a testing-only snapshot accessor on `LazyField` to validate internal state safely.
- Updated the package manifest and test imports so tests can switch between `VeinCore` and `VeinSwiftUI` via `TEST_SWIFTUI`.
- Changed macOS CI to run the full test suite twice: once for VeinCore and once for VeinSwiftUI.
- Added an Xcode test plan covering the package test bundles.

Especially nice here: the test suite now exercises both module variants, which should make regressions much harder to slip through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->