### PR TITLE
Added VeinSwiftUI unit tests (except `@Query`) and now reference tracks observers

### DIFF
--- a/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
@@ -80,17 +80,24 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         guard let model, let context = model.context else { return [] }
         guard !ids.isEmpty else { return [] }
         
+        if inverseKey.isNil {
+            inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+        }
+        
         do {
-            let observer: VeinObserver = (
-                id: model.id,
-                block: { [weak model] in
-                    guard !VeinNotificationGuard.isProcessing else { return }
-                    VeinNotificationGuard.$isProcessing.withValue(true) {
-                        model?.notifyOfChanges()
-                    }
-                }
-            )
-            let result = try context.getModels(ids: ids, type: T.self, observer: observer, requestingModel: model)
+            let observer: VeinObserver?
+            if let inverseKey {
+               observer = (
+                    id: model.id,
+                    key: inverseKey,
+                    block: { [weak model] in
+                        guard !VeinNotificationGuard.isProcessing else { return }
+                        VeinNotificationGuard.$isProcessing.withValue(true) {
+                            model?.notifyOfChanges()
+                        }
+                    })
+            } else { observer = nil }
+            let result = try context.getModels(ids: ids, type: T.self, observer: observer, requestingModel: model, fieldKey: instanceKey)
             return result
         } catch {
             if case .noSuchTable = error {
@@ -135,11 +142,13 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
             inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
         }
         
-        guard let inverseKey else { return }
-        
         for target in removed {
-            target._observers.value[model.id] = nil
-            model._observers.value[target.id] = nil
+            target._observers.value.removeObserver(id: model.id, key: instanceKey)
+
+            guard let inverseKey else {
+                continue
+            }
+            target._observers.value.removeObserver(id: target.id, key: inverseKey)
             
             target._setupFields()
             let predicateMatches = context._prepareForChange(of: target)
@@ -161,18 +170,10 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         }
         
         for target in added {
-            target._observers.value[model.id] = { [weak model] in
-                guard !VeinNotificationGuard.isProcessing else { return }
-                VeinNotificationGuard.$isProcessing.withValue(true) {
-                    model?.notifyOfChanges()
-                }
-            }
+            setObservers(on: target, id: target.id)
             
-            model._observers.value[target.id] = { [weak target] in
-                guard !VeinNotificationGuard.isProcessing else { return }
-                VeinNotificationGuard.$isProcessing.withValue(true) {
-                    target?.notifyOfChanges()
-                }
+            guard let inverseKey else {
+                continue
             }
             
             target._setupFields()
@@ -212,6 +213,31 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
             }
             
             context._markTouched(target, previouslyMatching: predicateMatches)
+        }
+    }
+    
+    private func setObservers(on target: T?, id: ULID) {
+        guard let model else { return }
+        lock.withLock {
+            if inverseKey == nil {
+                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            }
+        }
+        
+        target?._observers.value.addObserver(id: model.id, key: instanceKey, observer: { [weak model] in
+            guard !VeinNotificationGuard.isProcessing else { return }
+            VeinNotificationGuard.$isProcessing.withValue(true) {
+                model?.notifyOfChanges()
+            }
+        })
+        
+        if let inverseKey {
+            model._observers.value.addObserver(id: id, key: inverseKey, observer: { [weak target] in
+                guard !VeinNotificationGuard.isProcessing else { return }
+                VeinNotificationGuard.$isProcessing.withValue(true) {
+                    target?.notifyOfChanges()
+                }
+            })
         }
     }
     

--- a/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
@@ -85,19 +85,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         }
         
         do {
-            let observer: VeinObserver?
-            if let inverseKey {
-               observer = (
-                    id: model.id,
-                    key: inverseKey,
-                    block: { [weak model] in
-                        guard !VeinNotificationGuard.isProcessing else { return }
-                        VeinNotificationGuard.$isProcessing.withValue(true) {
-                            model?.notifyOfChanges()
-                        }
-                    })
-            } else { observer = nil }
-            let result = try context.getModels(ids: ids, type: T.self, observer: observer, requestingModel: model, fieldKey: instanceKey)
+            let result = try context.getModels(ids: ids, type: T.self, requestingModel: model, fieldKey: instanceKey, inverseKey: inverseKey)
             return result
         } catch {
             if case .noSuchTable = error {
@@ -148,7 +136,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
             guard let inverseKey else {
                 continue
             }
-            target._observers.value.removeObserver(id: target.id, key: inverseKey)
+            model._observers.value.removeObserver(id: target.id, key: inverseKey)
             
             target._setupFields()
             let predicateMatches = context._prepareForChange(of: target)

--- a/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
@@ -8,15 +8,27 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     public typealias Value = [T]
     public typealias PersistableRepresentation = [ULID]
     
-    public let isLazy: Bool = false
+    public var isLazy: Bool { false }
     private let lock = NSLock()
-    var idStore: [ULID]
-    public var inverseKey: String?
-    public var deleteRule: DeleteRule
+    @_spi(VeinTesting) public var idStore = [ULID]()
+    private let _inverseKey = Atomic<String?>(nil)
+    public var inverseKey: String? {
+        get {
+            _inverseKey.value
+        }
+        set {
+            _inverseKey.value = newValue
+        }
+    }
+    public let deleteRule: DeleteRule
     
     /// ONLY LET MACRO SET
+    /// it is not protected from other threads,
+    /// because proper use cannot change it to something wrong
     public var key: String?
     /// ONLY LET MACRO SET
+    /// it is not protected from other threads,
+    /// because proper use cannot change it to something wrong
     public weak var model: (any PersistentModel)?
     
     private var _wasTouched: Bool = false
@@ -37,27 +49,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     // Post insert: read from idStore
     public var wrappedValue: Value {
         get {
-            guard let model, let context = model.context else { return [] }
-            let ids = lock.withLock { idStore }
-            guard !ids.isEmpty else { return [] }
-            
-            do {
-                let observer: VeinObserver = (
-                    id: model.id,
-                    block: { [weak model] in model?.notifyOfChanges() }
-                )
-                let result = try context.getModels(ids: ids, type: T.self, observer: observer)
-                return result
-            } catch {
-                if case .noSuchTable = error {
-                    return []
-                }
-                if case .unexpectedlyEmptyResult = error {
-                    Self.logger.warning("Unexpectedly empty result for \(T.self)")
-                    return []
-                }
-                fatalError(error.localizedDescription)
-            }
+            get(for: lock.withLock { idStore })
         }
         set {
             guard
@@ -80,27 +72,58 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         inverse: String? = nil,
         deleteRule: DeleteRule = .nullify
     ) {
-        self.key = nil
-        self.idStore = []
-        self.inverseKey = inverse
+        self._inverseKey.value = inverse
         self.deleteRule = deleteRule
     }
     
-    private func setAndNotify(_ newValue: Value) {
-        let oldValue = wrappedValue
+    private func get(for ids: [ULID]) -> Value {
+        guard let model, let context = model.context else { return [] }
+        guard !ids.isEmpty else { return [] }
         
-        let oldIDs = Set(oldValue.map(\.id))
-        let newIDs = Set(newValue.map(\.id))
+        do {
+            let observer: VeinObserver = (
+                id: model.id,
+                block: { [weak model] in
+                    guard !VeinNotificationGuard.isProcessing else { return }
+                    VeinNotificationGuard.$isProcessing.withValue(true) {
+                        model?.notifyOfChanges()
+                    }
+                }
+            )
+            let result = try context.getModels(ids: ids, type: T.self, observer: observer, requestingModel: model)
+            return result
+        } catch {
+            if case .noSuchTable = error {
+                return []
+            }
+            if case .unexpectedlyEmptyResult = error {
+                Self.logger.warning("Unexpectedly empty result for \(T.self)")
+                return []
+            }
+            fatalError(error.localizedDescription)
+        }
+    }
+    
+    private func setAndNotify(_ newValue: Value) {
+        var oldIDs = [ULID]()
+        let newIDs = newValue.map(\.id)
+        lock.withLock {
+            oldIDs = idStore
+            idStore = newIDs
+        }
+        
+        let oldValue = get(for: oldIDs)
         
         let removed = oldValue.filter { !newIDs.contains($0.id) }
         let added = newValue.filter { !oldIDs.contains($0.id) }
         
-        lock.withLock {
-            idStore = newValue.map(\.id)
-        }
-        
         updateOtherSide(removed: removed, added: added)
-        model?.notifyOfChanges()
+        
+        if !VeinNotificationGuard.isProcessing {
+            VeinNotificationGuard.$isProcessing.withValue(true) {
+                model?.notifyOfChanges()
+            }
+        }
         
         wasTouched = true
     }
@@ -116,6 +139,8 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         
         for target in removed {
             target._observers.value[model.id] = nil
+            model._observers.value[target.id] = nil
+            
             target._setupFields()
             let predicateMatches = context._prepareForChange(of: target)
             
@@ -136,11 +161,32 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         }
         
         for target in added {
+            target._observers.value[model.id] = { [weak model] in
+                guard !VeinNotificationGuard.isProcessing else { return }
+                VeinNotificationGuard.$isProcessing.withValue(true) {
+                    model?.notifyOfChanges()
+                }
+            }
+            
+            model._observers.value[target.id] = { [weak target] in
+                guard !VeinNotificationGuard.isProcessing else { return }
+                VeinNotificationGuard.$isProcessing.withValue(true) {
+                    target?.notifyOfChanges()
+                }
+            }
+            
             target._setupFields()
             let predicateMatches = context._prepareForChange(of: target)
             
             let matchingField = target._fields.first { $0.key == inverseKey }
-            defer { target.notifyOfChanges() }
+            
+            defer {
+                if !VeinNotificationGuard.isProcessing {
+                    VeinNotificationGuard.$isProcessing.withValue(true) {
+                        target.notifyOfChanges()
+                    }
+                }
+            }
             
             do {
                 if target.context.isNil {
@@ -210,12 +256,12 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         else { return }
         
         for target in wrappedValue {
+            defer {
+                target.notifyOfChanges()
+            }
             switch deleteRule {
                 case .nullify:
                     let predicateMatches = context._prepareForChange(of: target)
-                    defer {
-                        target.notifyOfChanges()
-                    }
                     
                     let inverse = target._fields.first { $0.key == inverseKey }
                     

--- a/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
@@ -5,18 +5,30 @@ import Logging
 public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unchecked Sendable {
     static var logger: Logger { .init(label: "Vein.OneRelationship") }
     
-    public let isLazy: Bool = false
+    public var isLazy: Bool { false }
     public typealias Value = T?
     public typealias WrappedType = ULID?
     
     private let lock = NSLock()
     private var idStore: ULID?
-    public var inverseKey: String?
-    public var deleteRule: DeleteRule
+    private let _inverseKey = Atomic<String?>(nil)
+    public var inverseKey: String? {
+        get {
+            _inverseKey.value
+        }
+        set {
+            _inverseKey.value = newValue
+        }
+    }
+    public let deleteRule: DeleteRule
     
     /// ONLY LET MACRO SET
+    /// It is not protected from other threads,
+    /// because proper use cannot change it to something wrong
     public var key: String?
     /// ONLY LET MACRO SET
+    /// It is not protected from other threads,
+    /// because proper use cannot change it to something wrong
     public weak var model: (any PersistentModel)?
     
     private var _wasTouched: Bool = false
@@ -37,24 +49,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
     // Post insert: read from idStore
     public var wrappedValue: Value {
         get {
-            guard let model, let context = model.context else { return nil }
-            let id = lock.withLock { idStore }
-            guard let id else { return nil }
-            
-            do {
-                let result = try context.getModel(id: id, type: T.self)
-                result?._observers.value[model.id] = { [weak model] in model?.notifyOfChanges() }
-                return result
-            } catch {
-                if case .noSuchTable = error {
-                    return nil
-                }
-                if case .unexpectedlyEmptyResult = error {
-                    Self.logger.warning("Unexpectedly empty result for \(T.self)")
-                    return nil
-                }
-                fatalError(error.localizedDescription)
-            }
+            get(for: lock.withLock { idStore })
         }
         set {
             guard
@@ -96,48 +91,80 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         inverse: String? = nil,
         deleteRule: DeleteRule = .nullify
     ) {
-        self.key = nil
-        self.idStore = nil
-        self.inverseKey = inverse
+        self._inverseKey.value = inverse
         self.deleteRule = deleteRule
+    }
+    
+    private func get(for id: ULID?) -> Value {
+        guard let model, let context = model.context else { return nil }
+        guard let id else { return nil }
+        
+        do {
+            let result = try context.getModel(id: id, type: T.self)
+            
+            setObservers(on: result, id: id)
+            
+            return result
+        } catch {
+            if case .noSuchTable = error {
+                return nil
+            }
+            if case .unexpectedlyEmptyResult = error {
+                Self.logger.warning("Unexpectedly empty result for \(T.self)")
+                return nil
+            }
+            fatalError(error.localizedDescription)
+        }
     }
     
     private func setAndNotify(_ newValue: Value) {
         let newID = newValue?.id
-        let isDifferent = lock.withLock { idStore != newID }
-        
-        if isDifferent {
-            // Disconnect from the old relation first while wrappedValue points to it.
-            updateOtherSide(isRemoving: true)
-        }
+        var previousID: ULID?
         
         lock.withLock {
+            previousID = idStore
             idStore = newID
         }
         
-        if isDifferent {
-            // Connect to the new relation now that wrappedValue points to it.
-            updateOtherSide(isRemoving: false)
-        }
+        let isDifferent = previousID != newID
         
-        model?.notifyOfChanges()
+        VeinNotificationGuard.$isProcessing.withValue(true) {
+            if isDifferent {
+                // Disconnect from the old relation first while wrappedValue points to it.
+                updateOtherSide(isRemoving: true, id: previousID)
+            }
+            
+            if isDifferent {
+                // Connect to the new relation now that wrappedValue points to it.
+                updateOtherSide(isRemoving: false, id: newID)
+            }
+            
+            model?.notifyOfChanges()
+        }
         
         wasTouched = true
     }
     
-    private func updateOtherSide(isRemoving: Bool) {
+    private func updateOtherSide(isRemoving: Bool, id: ULID?) {
         guard let model, let context = model.context else { return }
         
-        if inverseKey.isNil {
-            inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+        lock.withLock {
+            if inverseKey == nil {
+                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            }
         }
         
         guard
             let inverseKey,
-            let target = wrappedValue
+            let target = get(for: id)
         else { return }
         
-        target._observers.value[model.id] = nil
+        if isRemoving {
+            target._observers.value[model.id] = nil
+            model._observers.value[target.id] = nil
+        } else {
+            setObservers(on: target, id: target.id)
+        }
         
         target._setupFields()
         
@@ -162,6 +189,26 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         }
         
         context._markTouched(target, previouslyMatching: predicateMatches)
+    }
+    
+    private func setObservers(on result: T?, id: ULID) {
+        guard let model else { return }
+        if result?._observers.value[model.id] == nil {
+            result?._observers.value[model.id] = { [weak model] in
+                guard !VeinNotificationGuard.isProcessing else { return }
+                VeinNotificationGuard.$isProcessing.withValue(true) {
+                    model?.notifyOfChanges()
+                }
+            }
+        }
+        if model._observers.value[id] == nil {
+            model._observers.value[id] = { [weak result] in
+                guard !VeinNotificationGuard.isProcessing else { return }
+                VeinNotificationGuard.$isProcessing.withValue(true) {
+                    result?.notifyOfChanges()
+                }
+            }
+        }
     }
     
     public func setStoreToCapturedState(_ state: Any) {
@@ -200,17 +247,27 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
     public func _handleModelDeletion() {
         guard
             let model,
-            let context = model.context,
+            let context = model.context
+        else { return }
+        
+        lock.withLock {
+            if inverseKey == nil {
+                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            }
+        }
+        
+        guard
             let inverseKey,
             let target = wrappedValue
         else { return }
         
+        defer {
+            target.notifyOfChanges()
+        }
+        
         switch deleteRule {
             case .nullify:
                 let predicateMatches = context._prepareForChange(of: target)
-                defer {
-                    target.notifyOfChanges()
-                }
                 
                 let inverse = target._fields.first { $0.key == inverseKey }
                 

--- a/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
@@ -154,14 +154,12 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
             }
         }
         
-        guard
-            let inverseKey,
-            let target = get(for: id)
-        else { return }
+        guard let target = get(for: id) else { return }
+        target._observers.value.removeObserver(id: model.id, key: instanceKey)
         
+        guard let inverseKey else { return }
         if isRemoving {
-            target._observers.value[model.id] = nil
-            model._observers.value[target.id] = nil
+            model._observers.value.removeObserver(id: target.id, key: inverseKey)
         } else {
             setObservers(on: target, id: target.id)
         }
@@ -191,23 +189,28 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         context._markTouched(target, previouslyMatching: predicateMatches)
     }
     
-    private func setObservers(on result: T?, id: ULID) {
+    private func setObservers(on target: T?, id: ULID) {
         guard let model else { return }
-        if result?._observers.value[model.id] == nil {
-            result?._observers.value[model.id] = { [weak model] in
-                guard !VeinNotificationGuard.isProcessing else { return }
-                VeinNotificationGuard.$isProcessing.withValue(true) {
-                    model?.notifyOfChanges()
-                }
+        lock.withLock {
+            if inverseKey == nil {
+                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
             }
         }
-        if model._observers.value[id] == nil {
-            model._observers.value[id] = { [weak result] in
+        
+        target?._observers.value.addObserver(id: model.id, key: instanceKey, observer: { [weak model] in
+            guard !VeinNotificationGuard.isProcessing else { return }
+            VeinNotificationGuard.$isProcessing.withValue(true) {
+                model?.notifyOfChanges()
+            }
+        })
+        
+        if let inverseKey {
+            model._observers.value.addObserver(id: id, key: inverseKey, observer: { [weak target] in
                 guard !VeinNotificationGuard.isProcessing else { return }
                 VeinNotificationGuard.$isProcessing.withValue(true) {
-                    result?.notifyOfChanges()
+                    target?.notifyOfChanges()
                 }
-            }
+            })
         }
     }
     

--- a/Sources/Vein/Model/PropertyWrappers/VeinNotificationGuard.swift
+++ b/Sources/Vein/Model/PropertyWrappers/VeinNotificationGuard.swift
@@ -1,0 +1,3 @@
+enum VeinNotificationGuard {
+    @TaskLocal static var isProcessing = false
+}

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -25,7 +25,7 @@ public protocol PersistentModel: AnyObject, Sendable {
     
     static var version: ModelVersion { get }
     
-    nonisolated var _observers: Atomic<[ULID: () -> Void]> { get }
+    nonisolated var _observers: Atomic<ReferenceCountedObservers> { get }
     
     static var _inverseFields: [ObjectIdentifier: [String: String]] { get }
     

--- a/Sources/Vein/Model/Values/ReferenceCountedObservers.swift
+++ b/Sources/Vein/Model/Values/ReferenceCountedObservers.swift
@@ -1,0 +1,28 @@
+import Foundation
+import ULID
+
+public struct ReferenceCountedObservers: @unchecked Sendable {
+    @_spi(VeinTesting) public var references = [ULID: Set<String>]()
+    @_spi(VeinTesting) public var observers = [ULID: () -> Void]()
+    
+    public mutating func addObserver(id: ULID, key: String, observer: @escaping () -> Void) {
+        references[id, default: []].insert(key)
+        if observers[id].isNil { observers[id] = observer }
+    }
+    
+    public mutating func removeObserver(id: ULID, key: String) {
+        references[id, default: []].remove(key)
+        if references[id]?.isEmpty == true {
+            observers.removeValue(forKey: id)
+            references.removeValue(forKey: id)
+        }
+    }
+    
+    public func notifyAll() {
+        for observer in observers.values {
+            observer()
+        }
+    }
+    
+    public init() {}
+}

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
@@ -17,7 +17,12 @@ extension ManagedObjectContext {
         ).first
     }
     
-    public nonisolated func getModels<T: PersistentModel>(ids: [ULID], type: T.Type, observer: VeinObserver) throws(MOCError) -> [T] {
+    public nonisolated func getModels<T: PersistentModel>(
+        ids: [ULID],
+        type: T.Type,
+        observer: VeinObserver,
+        requestingModel: any PersistentModel
+    ) throws(MOCError) -> [T] {
         var models = [ULID: T]()
         
         var identityMapMisses: [ULID] = []
@@ -39,6 +44,12 @@ extension ManagedObjectContext {
         for id in ids {
             if let model = models[id] {
                 model._observers.value[observer.id] = observer.block
+                requestingModel._observers.value[model.id] = { [weak model] in
+                    guard !VeinNotificationGuard.isProcessing else { return }
+                    VeinNotificationGuard.$isProcessing.withValue(true) {
+                        model?.notifyOfChanges()
+                    }
+                }
                 sortedModels.append(model)
             } else {
                 if !isInMigration {

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
@@ -2,8 +2,6 @@ import ULID
 import SQLiteDB
 import Foundation
 
-public typealias VeinObserver = (id: ULID, key: String, block: () -> Void)
-
 extension ManagedObjectContext {
     public nonisolated func getModel<T: PersistentModel>(id: ULID, type: T.Type) throws(MOCError) -> T? {
         if let model = identityMap.getTracked(type, id: id) {
@@ -20,9 +18,9 @@ extension ManagedObjectContext {
     public nonisolated func getModels<T: PersistentModel>(
         ids: [ULID],
         type: T.Type,
-        observer: VeinObserver?,
         requestingModel: any PersistentModel,
-        fieldKey: String
+        fieldKey: String,
+        inverseKey: String?
     ) throws(MOCError) -> [T] {
         var models = [ULID: T]()
         
@@ -43,17 +41,22 @@ extension ManagedObjectContext {
         var sortedModels: [T] = []
         let isInMigration = isInActiveMigration.value
         for id in ids {
-            if let model = models[id] {
-                if let observer {
-                    model._observers.value.addObserver(id: observer.id, key: observer.key, observer: observer.block)
-                }
-                requestingModel._observers.value.addObserver(id: model.id, key: fieldKey, observer: { [weak model] in
+            if let target = models[id] {
+                target._observers.value.addObserver(id: requestingModel.id, key: fieldKey, observer: {
                     guard !VeinNotificationGuard.isProcessing else { return }
                     VeinNotificationGuard.$isProcessing.withValue(true) {
-                        model?.notifyOfChanges()
+                        requestingModel.notifyOfChanges()
                     }
                 })
-                sortedModels.append(model)
+                if let inverseKey {
+                    requestingModel._observers.value.addObserver(id: target.id, key: inverseKey, observer: { [weak target] in
+                        guard !VeinNotificationGuard.isProcessing else { return }
+                        VeinNotificationGuard.$isProcessing.withValue(true) {
+                            target?.notifyOfChanges()
+                        }
+                    })
+                }
+                sortedModels.append(target)
             } else {
                 if !isInMigration {
                     Self.logger.warning(

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
@@ -2,7 +2,7 @@ import ULID
 import SQLiteDB
 import Foundation
 
-public typealias VeinObserver = (id: ULID, block: () -> Void)
+public typealias VeinObserver = (id: ULID, key: String, block: () -> Void)
 
 extension ManagedObjectContext {
     public nonisolated func getModel<T: PersistentModel>(id: ULID, type: T.Type) throws(MOCError) -> T? {
@@ -20,8 +20,9 @@ extension ManagedObjectContext {
     public nonisolated func getModels<T: PersistentModel>(
         ids: [ULID],
         type: T.Type,
-        observer: VeinObserver,
-        requestingModel: any PersistentModel
+        observer: VeinObserver?,
+        requestingModel: any PersistentModel,
+        fieldKey: String
     ) throws(MOCError) -> [T] {
         var models = [ULID: T]()
         
@@ -43,13 +44,15 @@ extension ManagedObjectContext {
         let isInMigration = isInActiveMigration.value
         for id in ids {
             if let model = models[id] {
-                model._observers.value[observer.id] = observer.block
-                requestingModel._observers.value[model.id] = { [weak model] in
+                if let observer {
+                    model._observers.value.addObserver(id: observer.id, key: observer.key, observer: observer.block)
+                }
+                requestingModel._observers.value.addObserver(id: model.id, key: fieldKey, observer: { [weak model] in
                     guard !VeinNotificationGuard.isProcessing else { return }
                     VeinNotificationGuard.$isProcessing.withValue(true) {
                         model?.notifyOfChanges()
                     }
-                }
+                })
                 sortedModels.append(model)
             } else {
                 if !isInMigration {

--- a/Sources/VeinSwiftUIMacros/ModelMacro.swift
+++ b/Sources/VeinSwiftUIMacros/ModelMacro.swift
@@ -30,9 +30,7 @@ public struct ModelMacro: MemberMacro, ExtensionMacro, MemberAttributeMacro {
         var notifyOfChanges: () -> Void {
             { [weak self] in
                 guard let self else { return }
-                for notification in self._observers.value.values {
-                    notification()
-                }
+                self._observers.value.notifyAll()
                 self.objectWillChange.send()
             }
         }

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -47,7 +47,7 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+                let _observers = Vein.Atomic(Vein.ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
@@ -144,7 +144,7 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+                let _observers = Vein.Atomic(Vein.ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
@@ -197,9 +197,7 @@ struct MacrosTests {
                 var notifyOfChanges: () -> Void {
                     { [weak self] in
                         guard let self else { return }
-                        for notification in self._observers.value.values {
-                            notification()
-                        }
+                        self._observers.value.notifyAll()
                         self.objectWillChange.send()
                     }
                 }
@@ -256,7 +254,7 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+                let _observers = Vein.Atomic(Vein.ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
@@ -352,7 +350,7 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+                let _observers = Vein.Atomic(Vein.ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
@@ -405,9 +403,7 @@ struct MacrosTests {
                 var notifyOfChanges: () -> Void {
                     { [weak self] in
                         guard let self else { return }
-                        for notification in self._observers.value.values {
-                            notification()
-                        }
+                        self._observers.value.notifyAll()
                         self.objectWillChange.send()
                     }
                 }

--- a/Tests/VeinTests/ReferenceCountedObserversTest.swift
+++ b/Tests/VeinTests/ReferenceCountedObserversTest.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Testing
-@testable import Vein
 #if TEST_SWIFTUI
 @_spi(VeinTesting) @testable import VeinSwiftUI
 #elseif !TEST_SWIFTUI
@@ -9,8 +8,8 @@ import Testing
 
 @Suite
 struct ReferenceCountedObserversTest {
-    @Test
-    mutating func `Observer is retained until all registered keys are removed`() {
+    @Test("Observer is retained until all registered keys are removed")
+    mutating func observerRetaining() {
         var tracker = ReferenceCountedObservers()
         let targetID = ULID()
         var notificationCount = 0
@@ -40,8 +39,8 @@ struct ReferenceCountedObserversTest {
         #expect(tracker.observers[targetID] == nil)
     }
     
-    @Test
-    func `Observers persist and clean up across multiple relationships`() throws {
+    @Test("Observers persist and clean up across multiple relationships (OneRelationship)")
+    func observerPersistanceAndCleanupOneRelationship() throws {
         let container = try ModelContainer(
             V0_0_1.self,
             migration: Migration.self,
@@ -56,25 +55,84 @@ struct ReferenceCountedObserversTest {
         try container.context.insert(child)
         
         let childID = child.id
+        let parentID = parent.id
         
         // 1. Act & Assert: Connect first relationship
         child.parent = parent
         #expect(parent._observers.value.references[childID]?.contains("parent") == true)
+        #expect(child._observers.value.references[parentID]?.contains("children") == true)
         
         // 2. Act & Assert: Connect second relationship
         child.test = parent
         #expect(parent._observers.value.references[childID] == ["parent", "test"])
         #expect(parent._observers.value.observers[childID] != nil)
         
+        #expect(child._observers.value.references[parentID] == ["children", "otherChildren"])
+        #expect(child._observers.value.observers[parentID] != nil)
+        
         // 3. Act & Assert: Disconnect first relationship
         child.parent = nil
         #expect(parent._observers.value.references[childID] == ["test"])
         #expect(parent._observers.value.observers[childID] != nil)
         
+        #expect(child._observers.value.references[parentID] == ["otherChildren"])
+        #expect(child._observers.value.observers[parentID] != nil)
+        
         // 4. Act & Assert: Disconnect second relationship
         child.test = nil
         #expect(parent._observers.value.references[childID] == nil)
         #expect(parent._observers.value.observers[childID] == nil)
+        
+        #expect(parent._observers.value.references[parentID] == nil)
+        #expect(parent._observers.value.observers[parentID] == nil)
+    }
+    
+    @Test("Observers persist and clean up across multiple relationships (ManyRelationship)")
+    func observerPersistanceAndCleanupManyRelationship() throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.observers"
+        )
+        
+        let parent = V0_0_1.Test()
+        let child = V0_0_1.Child()
+        
+        try container.context.insert(parent)
+        try container.context.insert(child)
+        
+        let childID = child.id
+        let parentID = parent.id
+        
+        // 1. Act & Assert: Connect first relationship
+        parent.children.append(child)
+        #expect(parent._observers.value.references[childID]?.contains("parent") == true)
+        #expect(child._observers.value.references[parentID]?.contains("children") == true)
+        
+        // 2. Act & Assert: Connect second relationship
+        parent.otherChildren.append(child)
+        #expect(parent._observers.value.references[childID] == ["parent", "test"])
+        #expect(parent._observers.value.observers[childID] != nil)
+        
+        #expect(child._observers.value.references[parentID] == ["children", "otherChildren"])
+        #expect(child._observers.value.observers[parentID] != nil)
+        
+        // 3. Act & Assert: Disconnect first relationship
+        parent.children = []
+        #expect(parent._observers.value.references[childID] == ["test"])
+        #expect(parent._observers.value.observers[childID] != nil)
+        
+        #expect(child._observers.value.references[parentID] == ["otherChildren"])
+        #expect(child._observers.value.observers[parentID] != nil)
+        
+        // 4. Act & Assert: Disconnect second relationship
+        parent.otherChildren = []
+        #expect(parent._observers.value.references[childID] == nil)
+        #expect(parent._observers.value.observers[childID] == nil)
+        
+        #expect(parent._observers.value.references[parentID] == nil)
+        #expect(parent._observers.value.observers[parentID] == nil)
     }
 }
 

--- a/Tests/VeinTests/ReferenceCountedObserversTest.swift
+++ b/Tests/VeinTests/ReferenceCountedObserversTest.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import Vein
+#if TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinCore
+#endif
+
+@Suite
+struct ReferenceCountedObserversTest {
+    @Test
+    mutating func `Observer is retained until all registered keys are removed`() {
+        var tracker = ReferenceCountedObservers()
+        let targetID = ULID()
+        var notificationCount = 0
+        let observer = { notificationCount += 1 }
+        
+        // 1. Add first relationship field
+        tracker.addObserver(id: targetID, key: "parent", observer: observer)
+        #expect(tracker.references[targetID] == ["parent"])
+        #expect(tracker.observers[targetID] != nil)
+        
+        // 2. Add second relationship field
+        tracker.addObserver(id: targetID, key: "test", observer: observer)
+        #expect(tracker.references[targetID] == ["parent", "test"])
+        
+        // 3. Remove first key; observer persists
+        tracker.removeObserver(id: targetID, key: "parent")
+        #expect(tracker.references[targetID] == ["test"])
+        #expect(tracker.observers[targetID] != nil)
+        
+        // Verify notification still triggers
+        tracker.notifyAll()
+        #expect(notificationCount == 1)
+        
+        // 4. Remove final key; observer is cleaned up
+        tracker.removeObserver(id: targetID, key: "test")
+        #expect(tracker.references[targetID] == nil)
+        #expect(tracker.observers[targetID] == nil)
+    }
+    
+    @Test
+    func `Observers persist and clean up across multiple relationships`() throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.observers"
+        )
+        
+        let parent = V0_0_1.Test()
+        let child = V0_0_1.Child()
+        
+        try container.context.insert(parent)
+        try container.context.insert(child)
+        
+        let childID = child.id
+        
+        // 1. Act & Assert: Connect first relationship
+        child.parent = parent
+        #expect(parent._observers.value.references[childID]?.contains("parent") == true)
+        
+        // 2. Act & Assert: Connect second relationship
+        child.test = parent
+        #expect(parent._observers.value.references[childID] == ["parent", "test"])
+        #expect(parent._observers.value.observers[childID] != nil)
+        
+        // 3. Act & Assert: Disconnect first relationship
+        child.parent = nil
+        #expect(parent._observers.value.references[childID] == ["test"])
+        #expect(parent._observers.value.observers[childID] != nil)
+        
+        // 4. Act & Assert: Disconnect second relationship
+        child.test = nil
+        #expect(parent._observers.value.references[childID] == nil)
+        #expect(parent._observers.value.observers[childID] == nil)
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self, Child.self]
+    
+    @Model
+    final class Test {
+        @Relationship(inverse: \Child.parent)
+        var children: [Child]
+        
+        @Relationship(inverse: \Child.test)
+        var otherChildren: [Child]
+        
+        init() {}
+    }
+    
+    @Model
+    final class Child {
+        @Relationship
+        var parent: Test?
+        
+        @Relationship
+        var test: Test?
+        
+        init() {}
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
+++ b/Tests/VeinTests/Relationships/RelationshiptDeleteRuleTest.swift
@@ -3,9 +3,9 @@ import Testing
 import Logging
 @testable import Vein
 #if TEST_SWIFTUI
-@testable import VeinSwiftUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
 #elseif !TEST_SWIFTUI
-@testable import VeinCore
+@_spi(VeinTesting) @testable import VeinCore
 #endif
 
 @MainActor

--- a/Tests/VeinTests/VeinSwiftUI/Wrappers.swift
+++ b/Tests/VeinTests/VeinSwiftUI/Wrappers.swift
@@ -1,0 +1,562 @@
+#if TEST_SWIFTUI
+import Foundation
+import Testing
+@testable import Vein
+@_spi(VeinTesting) @testable import VeinSwiftUI
+
+// For the "fetched" tests:
+//
+// Accessing the relationship property ensures that, if this model is being observed by a
+// SwiftUI view via a parent (e.g. parent.child.text), the observer is registered on this
+// instance through the identity map. Since the identity map guarantees a single instance
+// per row, any observer registered during a view's traversal of the relationship chain will
+// be the same instance mutated here — meaning objectWillChange fires correctly up the chain.
+// If no view has traversed to this instance via a parent, no observer exists and no redraw
+// is needed, so skipping the scan is correct rather than a bug.
+@Suite
+@MainActor
+struct VeinSwiftUITests {
+    @Test(.timeLimit(.minutes(1)))
+    func fieldUpdatesUIWithContext() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        try container.context.insert(model)
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.someValue = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func fieldUpdatesUIWithoutContext() async throws {
+        let model = V0_0_1.Test(someValue: "test")
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.someValue = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func lazyFieldUpdatesUIWithContext() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        try container.context.insert(model)
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.text = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func lazyFieldUpdatesUIWithoutContext() async throws {
+        let model = V0_0_1.Test(someValue: "test")
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.text = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func oneRelationshipUpdatesUI() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Child()
+        try container.context.insert(model)
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.parent = V0_0_1.Test(someValue: "test")
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func manyRelationshipUpdatesUI() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        try container.context.insert(model)
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.children.append(V0_0_1.Child())
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToChildUpdatesParent parent set on child`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(child)
+        child.parent = model
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            child.text = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToParentUpdatesChild child set on parent`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(model)
+        model.children.append(child)
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = child.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.text = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToChildUpdatesParent child set on parent`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(model)
+        model.children.append(child)
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            child.text = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToParentUpdatesChild parent set on child`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(child)
+        child.parent = model
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = child.objectWillChange.sink {
+                confirmed()
+            }
+            
+            model.text = "ioi"
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToFetchedChildUpdatesParent parent accessed via child`() async throws {
+        let connection = try prepareContainer()
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        guard let child = try container.context.fetchAll(V0_0_1.Child.self).first else {
+            Issue.record("Unexpectedly no child found.")
+            return
+        }
+        guard let parent = try container.context.fetchAll(V0_0_1.Test.self).first else {
+            Issue.record("Unexpectedly no parent found.")
+            return
+        }
+        
+        _ = child.parent
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = parent.objectWillChange.sink {
+                confirmed()
+            }
+            
+            child.text = "ioi"
+            
+            _ = cancellable
+        }
+        
+        func prepareContainer() throws -> Connection {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+            )
+            let model = V0_0_1.Test(someValue: "test")
+            let child = V0_0_1.Child()
+            try container.context.insert(model)
+            model.children.append(child)
+            
+            try container.context.save()
+            
+            return container.getConnection()
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToFetchedParentUpdatesChild parent accessed via child`() async throws {
+        let connection = try prepareContainer()
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        guard let child = try container.context.fetchAll(V0_0_1.Child.self).first else {
+            Issue.record("Unexpectedly no child found.")
+            return
+        }
+        guard let parent = try container.context.fetchAll(V0_0_1.Test.self).first else {
+            Issue.record("Unexpectedly no parent found.")
+            return
+        }
+        
+        _ = child.parent
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = child.objectWillChange.sink {
+                confirmed()
+            }
+            
+            parent.text = "ioi"
+            
+            _ = cancellable
+        }
+        
+        func prepareContainer() throws -> Connection {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+            )
+            let model = V0_0_1.Test(someValue: "test")
+            let child = V0_0_1.Child()
+            try container.context.insert(model)
+            model.children.append(child)
+            
+            try container.context.save()
+            
+            return container.getConnection()
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToFetchedChildUpdatesParent child accessed via parent`() async throws {
+        let connection = try prepareContainer()
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        guard let child = try container.context.fetchAll(V0_0_1.Child.self).first else {
+            Issue.record("Unexpectedly no child found.")
+            return
+        }
+        guard let parent = try container.context.fetchAll(V0_0_1.Test.self).first else {
+            Issue.record("Unexpectedly no parent found.")
+            return
+        }
+        
+        _ = parent.children
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = parent.objectWillChange.sink {
+                confirmed()
+            }
+            
+            child.text = "ioi"
+            
+            _ = cancellable
+        }
+        
+        func prepareContainer() throws -> Connection {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+            )
+            let model = V0_0_1.Test(someValue: "test")
+            let child = V0_0_1.Child()
+            try container.context.insert(model)
+            model.children.append(child)
+            
+            try container.context.save()
+            
+            return container.getConnection()
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `updateToFetchedParentUpdatesChild child accessed via parent`() async throws {
+        let connection = try prepareContainer()
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        guard let child = try container.context.fetchAll(V0_0_1.Child.self).first else {
+            Issue.record("Unexpectedly no child found.")
+            return
+        }
+        guard let parent = try container.context.fetchAll(V0_0_1.Test.self).first else {
+            Issue.record("Unexpectedly no parent found.")
+            return
+        }
+        
+        _ = parent.children
+        
+        await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = child.objectWillChange.sink {
+                confirmed()
+            }
+            
+            parent.text = "ioi"
+            
+            _ = cancellable
+        }
+        
+        func prepareContainer() throws -> Connection {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+            )
+            let model = V0_0_1.Test(someValue: "test")
+            let child = V0_0_1.Child()
+            try container.context.insert(model)
+            model.children.append(child)
+            
+            try container.context.save()
+            
+            return container.getConnection()
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `deleteChildUpdatesParent parent set on child`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(child)
+        child.parent = model
+        
+        try await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            try container.context.delete(child)
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `deleteParentUpdatesChild child set on parent`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(model)
+        model.children.append(child)
+        
+        try await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = child.objectWillChange.sink {
+                confirmed()
+            }
+            
+            try container.context.delete(model)
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `deleteChildUpdatesParent child set on parent`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(model)
+        model.children.append(child)
+        
+        try await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = model.objectWillChange.sink {
+                confirmed()
+            }
+            
+            try container.context.delete(child)
+            
+            _ = cancellable
+        }
+    }
+    
+    @Test(.timeLimit(.minutes(1)))
+    func `deleteParentUpdatesChild parent set on child`() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.veinswiftui.fields-update-model"
+        )
+        let model = V0_0_1.Test(someValue: "test")
+        let child = V0_0_1.Child()
+        try container.context.insert(child)
+        child.parent = model
+        
+        try await confirmation("Confirm objectWillChange was signaled", expectedCount: 1) { confirmed in
+            let cancellable = child.objectWillChange.sink {
+                confirmed()
+            }
+            
+            try container.context.delete(model)
+            
+            _ = cancellable
+        }
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self, Child.self]
+    
+    @Model
+    final class Test {
+        var someValue: String
+        
+        @LazyField
+        var text: String?
+        
+        @Relationship(inverse: \Child.parent)
+        var children: [Child]
+        
+        init(someValue: String) {
+            self.someValue = someValue
+        }
+    }
+    
+    @Model
+    final class Child {
+        @Relationship
+        var parent: Test?
+        
+        @LazyField
+        var text: String?
+        
+        init() {}
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}
+#endif

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -133,7 +133,7 @@ required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
     _setupFields()
 }
 
-let _observers = Vein.Atomic([Vein.ULID: () -> Void]())
+let _observers = Vein.Atomic(Vein.ReferenceCountedObservers())
 
 /// Sets required properties for @Field values.
 /// Gets generated automatically by @Model.


### PR DESCRIPTION
Resolves https://github.com/amethystsoft/vein/issues/42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Added VeinSwiftUI unit tests that verify `objectWillChange` behavior for property updates, relationship mutations, and deletions.
- Reworked observer storage from a plain callback dictionary to `ReferenceCountedObservers`, enabling keyed, reference-counted observer tracking.
- Updated relationship handling to use guarded notification flow and avoid re-entrant change loops.
- Aligned macro-generated model code and test expectations with the new observer system.

### Tests
- Added new `ReferenceCountedObservers` unit coverage.
- Added SwiftUI wrapper tests for model and relationship update notifications.
- Updated macro expansion tests to match the new generated observer storage and notification dispatch.

### Highlight
- Strong improvement: the new reference-counted observer model plus `VeinNotificationGuard` makes change notifications much safer and more predictable, especially for SwiftUI-style observation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->