### PR TITLE
Update roadmap in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Amethyst Vein
 
 ## Roadmap to 1.0
-- [ ] Support plugging in a logger for better debug experience
-- [ ] Documentation. Loads of documentation and tutorials.
-- [ ] Generate fields that will be required by sync solutions in 2.0 to avoid annoying migrations
-- [ ] fix testing on release build
-- [ ] Resolve remaining issues
+- Take a look at currently open issues
 
 If using encryption on Linux, set app identifier before using model context
 ```swift


### PR DESCRIPTION
Removed several roadmap items from the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the README roadmap to remove the previous 1.0 milestone items and replace them with a pointer to the currently open issues.

Nice touch: this keeps the roadmap lighter and directs contributors to the most up-to-date source of planned work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->