### PR TITLE
Autogenerate sync required fields

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: MiaKoring

--- a/Sources/Vein/Model/PropertyWrappers/Fields.swift
+++ b/Sources/Vein/Model/PropertyWrappers/Fields.swift
@@ -16,6 +16,8 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
     /// ONLY LET MACRO SET
     public weak var model: (any PersistentModel)?
     
+    @_spi(VeinTesting) public let suppressUIUpdates: Bool
+    
     private var _wasTouched: Bool = false
     public private(set) var wasTouched: Bool {
         get {
@@ -79,18 +81,10 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
         }
     }
     
-    /* TODO: add async fetch
-    public func readAsynchronously() async throws -> T? {
-        guard let context = model?.context else {
-            return store
-        }
-        return try await context.fetchSingleProperty(field: self)
-    }
-    */
-    
-    public init(wrappedValue: T?) {
+    public init(wrappedValue: T? = nil, suppressUIUpdates: Bool = false) {
         self.key = nil
         self.store = wrappedValue
+        self.suppressUIUpdates = suppressUIUpdates
     }
     
     private func setAndNotify(_ newValue: WrappedType) {
@@ -98,7 +92,9 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
             store = newValue
             readFromStore = true
         }
-        model?.notifyOfChanges()
+        if !suppressUIUpdates {
+            model?.notifyOfChanges()
+        }
     }
     
     public func setStoreToCapturedState(_ state: Any) {

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -34,6 +34,12 @@ public protocol PersistentModel: AnyObject, Sendable {
     
     static func _predicateInformation(for keyPath: PartialKeyPath<Self>) -> FieldInformation?
     
+    var _updatedAt: Foundation.Date? { get set }
+    
+    var _clientID: String? { get set }
+    
+    var _isDeleted: Bool? { get set }
+    
     init(id: ULID, fields: [String: SQLiteValue])
 }
 

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
@@ -11,6 +11,7 @@ extension ManagedObjectContext {
                     .asPersistentRepresentation
                     .sqliteSetter(key: $0.instanceKey)
             }
+            
             try connection.run(table.insert(values))
         } catch let error as ManagedObjectContextError { throw error }
         catch let error as SQLiteDB.Result {

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Surface.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Surface.swift
@@ -50,6 +50,7 @@ extension ManagedObjectContext {
     }
     
     public nonisolated func insert<M: PersistentModel>(_ model: M) throws(ManagedObjectContextError) {
+        _updateModelMetadata(on: model)
         guard model.context == nil else {
             throw MOCError.insertManagedModel(message: "raised by model of type '\(M.self)' with id \(model.id.ulidString)")
         }
@@ -126,6 +127,8 @@ extension ManagedObjectContext {
                 default: [:]
             ][model.id] = model
         }
+        
+        _updateModelMetadata(on: model)
         
         guard
             let observers = registeredQueries.value[model.typeIdentifier],
@@ -415,6 +418,15 @@ extension ManagedObjectContext {
                 inserts.removeAll()
                 touches.removeAll()
                 deletes.removeAll()
+            }
+        }
+    }
+    
+    nonisolated func _updateModelMetadata(on model: any PersistentModel) {
+        if !Self.isSettingInternalMetdata {
+            Self.$isSettingInternalMetdata.withValue(true) {
+                model._updatedAt = Date()
+                model._clientID = clientID
             }
         }
     }

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -16,6 +16,28 @@ public actor ManagedObjectContext {
     package nonisolated let connection: SQLiteDB.Connection
     nonisolated unowned let modelContainer: ModelContainer
     
+    @TaskLocal static var isSettingInternalMetdata = false
+    
+    nonisolated let _clientID = Atomic<String?>(nil)
+    nonisolated var clientID: String {
+        _clientID.mutate { clientID in
+            if let clientID {
+                return clientID
+            }
+            
+            let key = "de.amethystsoft.vein-database.clientID"
+            if let stored = UserDefaults.standard.string(forKey: key) {
+                clientID = stored
+                return stored
+            }
+            let id = UUID().uuidString
+            UserDefaults.standard.set(id, forKey: key)
+
+            clientID = id
+            return id
+        }
+    }
+    
     // MARK: - Migrations
     package nonisolated let isInActiveMigration = Atomic(false)
     

--- a/Sources/VeinCore/ModelMacro.swift
+++ b/Sources/VeinCore/ModelMacro.swift
@@ -1,6 +1,6 @@
 @_exported import Vein
 
-@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation))
+@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation), named(_updatedAt), named(_clientID), named(_isDeleted))
 @attached(extension, conformances: PersistentModel, Sendable, names: named(version), named(schema))
 @attached(memberAttribute)
 public macro Model() = #externalMacro(

--- a/Sources/VeinSwiftUI/ModelMacro.swift
+++ b/Sources/VeinSwiftUI/ModelMacro.swift
@@ -2,7 +2,7 @@
 @_exported import Combine
 import Vein
 
-@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation))
+@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation), named(_updatedAt), named(_clientID), named(_isDeleted))
 @attached(extension, conformances: PersistentModel, Sendable, ObservableObject, names: named(version), named(schema))
 @attached(memberAttribute)
 public macro Model() = #externalMacro(

--- a/Tests/VeinTests/Bugs/BugTests.swift
+++ b/Tests/VeinTests/Bugs/BugTests.swift
@@ -5,9 +5,9 @@ import SQLiteDB
 @testable import Vein
 
 #if TEST_SWIFTUI
-@testable import VeinSwiftUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
 #elseif !TEST_SWIFTUI
-@testable import VeinCore
+@_spi(VeinTesting) @testable import VeinCore
 #endif
 
 @Suite
@@ -42,6 +42,25 @@ struct BugTests {
         
         let result2 = try newContainer.context.getModel(id: model2.id, type: V0_0_1.User.self)
         #expect(result2?.name == model2.name)
+    }
+    
+    @Test
+    func `validateMetadataFields`() async throws {
+        let model = V0_0_1.User(name: "Test")
+        model._setupFields()
+        let fields = model._fields
+        guard
+            let updatedAt = fields.first(where: { $0.key == "_updatedAt" }) as? LazyField<Date>,
+            let isDeleted = fields.first(where: { $0.key == "_isDeleted" }) as? LazyField<Bool>,
+            let clientID = fields.first(where: { $0.key == "_clientID" }) as? LazyField<String>
+        else {
+            Issue.record("One or more metadata fields are missing. Got: \(fields.map(\.key))")
+            return
+        }
+        #expect(isDeleted.wrappedValue == false)
+        #expect(isDeleted.suppressUIUpdates)
+        #expect(updatedAt.suppressUIUpdates)
+        #expect(clientID.suppressUIUpdates)
     }
 }
 

--- a/Tests/VeinTests/Context/TestWriteCache.swift
+++ b/Tests/VeinTests/Context/TestWriteCache.swift
@@ -26,7 +26,20 @@ struct WriteCache {
         let container = try setupContainer()
         let model = V0_0_1.Test(flag: true, someValue: "Hello", randomValue: 42)
         
+        let clientID = container.context.clientID
+        let currentTime = Date().timeIntervalSince1970
+        
         try container.context.insert(model)
+        
+        let endTime = Date().timeIntervalSince1970
+        
+        guard let updatedAt = model._updatedAt?.timeIntervalSince1970 else {
+            Issue.record("updatedAt was unexpectedly found nil.")
+            return
+        }
+        #expect(updatedAt >= currentTime)
+        #expect(updatedAt <= endTime + 0.1)
+        #expect(model._clientID == clientID)
         
         #expect(container.context.hasChanges == true)
         #expect(model.context === container.context)
@@ -49,7 +62,21 @@ struct WriteCache {
         model.context = container.context
         model._setupFields()
         
+        let clientID = container.context.clientID
+        let currentTime = Date().timeIntervalSince1970
+        
         model.someValue = "Updated"
+        
+        let endTime = Date().timeIntervalSince1970
+        
+        guard let updatedAt = model._updatedAt?.timeIntervalSince1970 else {
+            Issue.record("updatedAt was unexpectedly found nil.")
+            return
+        }
+        
+        #expect(updatedAt >= currentTime)
+        #expect(updatedAt <= endTime + 0.1)
+        #expect(model._clientID == clientID)
         
         #expect(container.context.hasChanges == true)
         container.context.writeCache.mutate { _, touches,_, states in

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -36,6 +36,15 @@ struct MacrosTests {
                 @Vein.PrimaryKey
                 var id: Vein.ULID
             
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _updatedAt: Foundation.Date?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _clientID: String?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _isDeleted: Bool? = false
+            
                 required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                     self.id = id
                     self.test = try! String.init(
@@ -52,6 +61,12 @@ struct MacrosTests {
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
+                    self.__clientID.model = self
+                    self.__clientID.key = "_clientID"
+                    self.__isDeleted.model = self
+                    self.__isDeleted.key = "_isDeleted"
+                    self.__updatedAt.model = self
+                    self.__updatedAt.key = "_updatedAt"
                     self._test.model = self
                     self._test.key = "test"
                     self._id.model = self
@@ -67,6 +82,9 @@ struct MacrosTests {
                 var _fields: [any Vein.FieldBase] {
                     [
                         self._id,
+                        self.__clientID,
+                        self.__isDeleted,
+                        self.__updatedAt,
                         self._test
                     ]
                 }
@@ -85,6 +103,9 @@ struct MacrosTests {
             
                 static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
                     switch keyPath {
+                        case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
+                        case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                        case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                         case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
                         default: nil
@@ -92,6 +113,9 @@ struct MacrosTests {
                 }
             
                 static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
+                    Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                    Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                     Vein.FieldInformation(String.sqliteTypeName, "test", true)
                 ]
             
@@ -132,6 +156,15 @@ struct MacrosTests {
                 /// Immutable after insertion into the context.
                 @Vein.PrimaryKey
                 var id: Vein.ULID
+
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _updatedAt: Foundation.Date?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _clientID: String?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _isDeleted: Bool? = false
             
                 required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                     self.id = id
@@ -149,6 +182,12 @@ struct MacrosTests {
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
+                    self.__clientID.model = self
+                    self.__clientID.key = "_clientID"
+                    self.__isDeleted.model = self
+                    self.__isDeleted.key = "_isDeleted"
+                    self.__updatedAt.model = self
+                    self.__updatedAt.key = "_updatedAt"
                     self._test.model = self
                     self._test.key = "test"
                     self._id.model = self
@@ -164,6 +203,9 @@ struct MacrosTests {
                 var _fields: [any Vein.FieldBase] {
                     [
                         self._id,
+                        self.__clientID,
+                        self.__isDeleted,
+                        self.__updatedAt,
                         self._test
                     ]
                 }
@@ -182,6 +224,9 @@ struct MacrosTests {
             
                 static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
                     switch keyPath {
+                        case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
+                        case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                        case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                         case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
                         default: nil
@@ -189,6 +234,9 @@ struct MacrosTests {
                 }
             
                 static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
+                    Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                    Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                     Vein.FieldInformation(String.sqliteTypeName, "test", true)
                 ]
             
@@ -243,6 +291,15 @@ struct MacrosTests {
                 @Vein.PrimaryKey
                 var id: Vein.ULID
             
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _updatedAt: Foundation.Date?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _clientID: String?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _isDeleted: Bool? = false
+            
                 required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                     self.id = id
                     self.test = try! String.init(
@@ -259,6 +316,12 @@ struct MacrosTests {
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
+                    self.__clientID.model = self
+                    self.__clientID.key = "_clientID"
+                    self.__isDeleted.model = self
+                    self.__isDeleted.key = "_isDeleted"
+                    self.__updatedAt.model = self
+                    self.__updatedAt.key = "_updatedAt"
                     self._test.model = self
                     self._test.key = "test"
                     self._id.model = self
@@ -274,6 +337,9 @@ struct MacrosTests {
                 var _fields: [any Vein.FieldBase] {
                     [
                         self._id,
+                        self.__clientID,
+                        self.__isDeleted,
+                        self.__updatedAt,
                         self._test
                     ]
                 }
@@ -292,6 +358,9 @@ struct MacrosTests {
             
                 static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
                     switch keyPath {
+                        case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
+                        case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                        case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                         case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
                         default: nil
@@ -299,6 +368,9 @@ struct MacrosTests {
                 }
             
                 static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
+                    Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                    Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                     Vein.FieldInformation(String.sqliteTypeName, "test", true)
                 ]
             
@@ -338,6 +410,15 @@ struct MacrosTests {
                 /// Immutable after insertion into the context.
                 @Vein.PrimaryKey
                 var id: Vein.ULID
+
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _updatedAt: Foundation.Date?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _clientID: String?
+            
+                @Vein.LazyField(suppressUIUpdates: true)
+                var _isDeleted: Bool? = false
             
                 required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                     self.id = id
@@ -355,6 +436,12 @@ struct MacrosTests {
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
+                    self.__clientID.model = self
+                    self.__clientID.key = "_clientID"
+                    self.__isDeleted.model = self
+                    self.__isDeleted.key = "_isDeleted"
+                    self.__updatedAt.model = self
+                    self.__updatedAt.key = "_updatedAt"
                     self._test.model = self
                     self._test.key = "test"
                     self._id.model = self
@@ -370,6 +457,9 @@ struct MacrosTests {
                 var _fields: [any Vein.FieldBase] {
                     [
                         self._id,
+                        self.__clientID,
+                        self.__isDeleted,
+                        self.__updatedAt,
                         self._test
                     ]
                 }
@@ -388,6 +478,9 @@ struct MacrosTests {
             
                 static func _predicateInformation(for keyPath: PartialKeyPath<Test>) -> Vein.FieldInformation? {
                     switch keyPath {
+                        case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
+                        case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                        case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                         case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
                         default: nil
@@ -395,6 +488,9 @@ struct MacrosTests {
                 }
             
                 static let _fieldInformation: [Vein.FieldInformation] = [
+                    Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
+                    Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                    Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                     Vein.FieldInformation(String.sqliteTypeName, "test", true)
                 ]
             

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -30,7 +30,11 @@ public struct ModelMacroBase {
             .membersWithFieldType(.relationship, frameworkName: frameworkName)
         
         let relationshipFields = relationshipVariables.fields()
-        let lazyFields = lazyFieldVariables.fields()
+        var lazyFields = lazyFieldVariables.fields()
+        lazyFields["_updatedAt"] = "Foundation.Date?"
+        lazyFields["_clientID"] = "String?"
+        lazyFields["_isDeleted"] = "Bool?"
+        
         let eagerFields = fieldVariables.fields()
         
         // MARK: - Setup Fields & _fields accessor
@@ -42,7 +46,7 @@ public struct ModelMacroBase {
         
         fieldAccessorBodies.append("self._id")
         
-        for name in allFieldNames {
+        for name in allFieldNames.sorted(by: { $0 < $1 }) {
             // This is not needed in every case, but its handy for internal ones
             // not using the wrappedValue.
             fieldBodys.append("self._\(name).model = self")
@@ -58,19 +62,19 @@ public struct ModelMacroBase {
         // MARK: - Field information
         var predicateInformation: [String] = []
         var fieldInformation: [String] = []
-        for (key, value) in lazyFields {
+        for (key, value) in lazyFields.sorted(by: { $0.key < $1.key }) {
             let value = value.drop(while: { $0 == " " || $0 == ":" })
             let information = "Vein.FieldInformation(\(value).sqliteTypeName, \"\(key)\", false)"
             fieldInformation.append(information)
             predicateInformation.append("case \\.\(key): \(information)")
         }
-        for (key, value) in eagerFields {
+        for (key, value) in eagerFields.sorted(by: { $0.key < $1.key }) {
             let value = value.drop(while: { $0 == " " || $0 == ":" })
             let information = "Vein.FieldInformation(\(value).sqliteTypeName, \"\(key)\", true)"
             fieldInformation.append(information)
             predicateInformation.append("case \\.\(key): \(information)")
         }
-        for (key, value) in relationshipFields {
+        for (key, value) in relationshipFields.sorted(by: { $0.key < $1.key }) {
             let relationshipType = "\(value.coreRelationshipType).self"
             // currently only ULID or ULID array is supported
             let value = value.isCollection ? "[ULID]": "ULID?"
@@ -125,6 +129,15 @@ public struct ModelMacroBase {
 /// Immutable after insertion into the context.
 @Vein.PrimaryKey
 var id: Vein.ULID
+
+@Vein.LazyField(suppressUIUpdates: true)
+var _updatedAt: Foundation.Date?
+
+@Vein.LazyField(suppressUIUpdates: true)
+var _clientID: String?
+
+@Vein.LazyField(suppressUIUpdates: true)
+var _isDeleted: Bool? = false
 
 required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
     self.id = id
@@ -296,7 +309,7 @@ extension FieldType {
 
 extension MemberBlockSyntax {
     func membersWithFieldType(_ type: FieldType, frameworkName: String) -> [VariableDeclSyntax] {
-        members.compactMap { (member: MemberBlockItemSyntax) -> VariableDeclSyntax? in
+        let result = members.compactMap { (member: MemberBlockItemSyntax) -> VariableDeclSyntax? in
             guard let varDecl = member.decl.as(VariableDeclSyntax.self) else {
                 return nil
             }
@@ -305,6 +318,8 @@ extension MemberBlockSyntax {
             
             return hasFieldAttribute ? varDecl : nil
         }
+        
+        return result
     }
 }
 


### PR DESCRIPTION
resolves https://github.com/amethystsoft/vein/issues/48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Implemented automatic generation of the sync-ready model metadata fields required for future synchronization: `_updatedAt`, `_clientID`, and `_isDeleted` (with `_isDeleted` generated but not yet used).

Highlights:
- `PersistentModel` now requires the new metadata properties.
- Model macro expansion now generates the new lazy fields and wires them into field/predicate metadata.
- `ManagedObjectContext` now assigns `updatedAt` and a stable per-client `clientID` on insert/update.
- Added persistent `clientID` generation/storage plus internal metadata-setting guards.
- Expanded tests to verify generated fields, macro output, and metadata tracking behavior.

Nice work making the sync foundation land cleanly without forcing a later migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->