### PR TITLE
updated ULID Tests to swift testing

### DIFF
--- a/Sources/ULID/Data+Base32.swift
+++ b/Sources/ULID/Data+Base32.swift
@@ -5,6 +5,7 @@
 //  Created by Yasuhiro Hatta on 2019/01/11.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
+// copied at https://github.com/yaslab/ULID.swift/tree/15c21a2f4a6d27f65df2468c5338c949ae857903
 
 import Foundation
 

--- a/Sources/ULID/ULID.swift
+++ b/Sources/ULID/ULID.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2019 yaslab. All rights reserved.
 //
 //  Adapted for Amethyst Vein to resolve concurrent metadata TSan false positives.
+//
+// copied at https://github.com/yaslab/ULID.swift/tree/15c21a2f4a6d27f65df2468c5338c949ae857903
 
 import Foundation
 

--- a/Sources/ULID/ULID.swift
+++ b/Sources/ULID/ULID.swift
@@ -62,16 +62,12 @@ public struct ULID: Hashable, Equatable, Comparable, CustomStringConvertible, Se
                     i += 1
                 }
             }
-            var randomPart:Data = Data()
-            if data.count > randomDataInBytes{
-                randomPart = data.prefix(randomDataInBytes)
-            }else{
-                randomPart = data
-            }
             
-            withUnsafeBytes(of: &randomPart) {
-                for j in 0 ..< 10 {
-                    buffer[i] = $0[j]
+            let randomPart = data.prefix(randomDataInBytes)
+            
+            randomPart.withUnsafeBytes { (randomBuffer: UnsafeRawBufferPointer) in
+                for j in 0 ..< randomDataInBytes {
+                    buffer[i] = randomBuffer[j]
                     i += 1
                 }
             }
@@ -80,59 +76,55 @@ public struct ULID: Hashable, Equatable, Comparable, CustomStringConvertible, Se
 
     /// Create a ULID with the given timestamp and random number generator.
     public init<T: RandomNumberGenerator>(timestamp: Date, generator: inout T) {
-        withUnsafeMutableBytes(of: &ulid) { (buffer) in
-            var i = 0
-            var millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0).bigEndian
-            withUnsafeBytes(of: &millisec) {
-                for j in 2 ..< 8 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-            var random16 = UInt16.random(in: .min ... .max, using: &generator).bigEndian
-            withUnsafeBytes(of: &random16) {
-                for j in 0 ..< 2 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-            var random64 = UInt64.random(in: .min ... .max, using: &generator).bigEndian
-            withUnsafeBytes(of: &random64) {
-                for j in 0 ..< 8 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-        }
+        let millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0)
+        let r16 = UInt16.random(in: .min ... .max, using: &generator)
+        let r64 = UInt64.random(in: .min ... .max, using: &generator)
+        
+        self.ulid = (
+            UInt8((millisec >> 40) & 0xFF),
+            UInt8((millisec >> 32) & 0xFF),
+            UInt8((millisec >> 24) & 0xFF),
+            UInt8((millisec >> 16) & 0xFF),
+            UInt8((millisec >> 8) & 0xFF),
+            UInt8(millisec & 0xFF),
+            UInt8((r16 >> 8) & 0xFF),
+            UInt8(r16 & 0xFF),
+            UInt8((r64 >> 56) & 0xFF),
+            UInt8((r64 >> 48) & 0xFF),
+            UInt8((r64 >> 40) & 0xFF),
+            UInt8((r64 >> 32) & 0xFF),
+            UInt8((r64 >> 24) & 0xFF),
+            UInt8((r64 >> 16) & 0xFF),
+            UInt8((r64 >> 8) & 0xFF),
+            UInt8(r64 & 0xFF)
+        )
     }
 
     /// Create a ULID with the given timestamp.
     public init(timestamp: Date = Date()) {
         var generator = SystemRandomNumberGenerator()
-        withUnsafeMutableBytes(of: &ulid) { (buffer) in
-            var i = 0
-            var millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0).bigEndian
-            withUnsafeBytes(of: &millisec) {
-                for j in 2 ..< 8 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-            var random16 = UInt16.random(in: .min ... .max, using: &generator).bigEndian
-            withUnsafeBytes(of: &random16) {
-                for j in 0 ..< 2 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-            var random64 = UInt64.random(in: .min ... .max, using: &generator).bigEndian
-            withUnsafeBytes(of: &random64) {
-                for j in 0 ..< 8 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-        }
+        let millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0)
+        let r16 = UInt16.random(in: .min ... .max, using: &generator)
+        let r64 = UInt64.random(in: .min ... .max, using: &generator)
+        
+        self.ulid = (
+            UInt8((millisec >> 40) & 0xFF),
+            UInt8((millisec >> 32) & 0xFF),
+            UInt8((millisec >> 24) & 0xFF),
+            UInt8((millisec >> 16) & 0xFF),
+            UInt8((millisec >> 8) & 0xFF),
+            UInt8(millisec & 0xFF),
+            UInt8((r16 >> 8) & 0xFF),
+            UInt8(r16 & 0xFF),
+            UInt8((r64 >> 56) & 0xFF),
+            UInt8((r64 >> 48) & 0xFF),
+            UInt8((r64 >> 40) & 0xFF),
+            UInt8((r64 >> 32) & 0xFF),
+            UInt8((r64 >> 24) & 0xFF),
+            UInt8((r64 >> 16) & 0xFF),
+            UInt8((r64 >> 8) & 0xFF),
+            UInt8(r64 & 0xFF)
+        )
     }
 
     /// Returns a raw binary data.

--- a/Tests/ULIDTests/Data+Base32Tests.swift
+++ b/Tests/ULIDTests/Data+Base32Tests.swift
@@ -5,16 +5,21 @@
 //  Created by Yasuhiro Hatta on 2019/01/12.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
-#if !os(Android)
-import XCTest
+//  Adapted for Amethyst Vein
+//
+//  copied at https://github.com/yaslab/ULID.swift/tree/15c21a2f4a6d27f65df2468c5338c949ae857903
+
+import Foundation
+import Testing
 @testable import ULID
 
-final class Base32Tests: XCTestCase {
+@Suite
+struct Base32Tests {
 
     // MARK: -
     // MARK: Encode
 
-    func testEncodeBase32() {
+    @Test func testEncodeBase32() {
         let expected = "00000001D0YX86C6ZTSZJNXFHDQMCYBQ"
 
         let bytes: [UInt8] = [
@@ -23,130 +28,130 @@ final class Base32Tests: XCTestCase {
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual(expected, data.base32EncodedString())
+        #expect(expected == data.base32EncodedString())
     }
 
-    func testEncode1() {
+    @Test func testEncode1() {
         let bytes: [UInt8] = [
             0b11111000, 0b00000000, 0b00000000, 0b00000000, 0b00000000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("Z0000000", data.base32EncodedString())
+        #expect("Z0000000" == data.base32EncodedString())
     }
 
-    func testEncode2() {
+    @Test func testEncode2() {
         let bytes: [UInt8] = [
             0b00000111, 0b11000000, 0b00000000, 0b00000000, 0b00000000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("0Z000000", data.base32EncodedString())
+        #expect("0Z000000" == data.base32EncodedString())
     }
 
-    func testEncode3() {
+    @Test func testEncode3() {
         let bytes: [UInt8] = [
             0b00000000, 0b00111110, 0b00000000, 0b00000000, 0b00000000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("00Z00000", data.base32EncodedString())
+        #expect("00Z00000" == data.base32EncodedString())
     }
 
-    func testEncode4() {
+    @Test func testEncode4() {
         let bytes: [UInt8] = [
             0b00000000, 0b00000001, 0b11110000, 0b00000000, 0b00000000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("000Z0000", data.base32EncodedString())
+        #expect("000Z0000" == data.base32EncodedString())
     }
 
-    func testEncode5() {
+    @Test func testEncode5() {
         let bytes: [UInt8] = [
             0b00000000, 0b00000000, 0b00001111, 0b10000000, 0b00000000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("0000Z000", data.base32EncodedString())
+        #expect("0000Z000" == data.base32EncodedString())
     }
 
-    func testEncode6() {
+    @Test func testEncode6() {
         let bytes: [UInt8] = [
             0b00000000, 0b00000000, 0b00000000, 0b01111100, 0b00000000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("00000Z00", data.base32EncodedString())
+        #expect("00000Z00" == data.base32EncodedString())
     }
 
-    func testEncode7() {
+    @Test func testEncode7() {
         let bytes: [UInt8] = [
             0b00000000, 0b00000000, 0b00000000, 0b00000011, 0b11100000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("000000Z0", data.base32EncodedString())
+        #expect("000000Z0" == data.base32EncodedString())
     }
 
-    func testEncode8() {
+    @Test func testEncode8() {
         let bytes: [UInt8] = [
             0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00011111
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("0000000Z", data.base32EncodedString())
+        #expect("0000000Z" == data.base32EncodedString())
     }
 
-    func testEncodePad1() {
+    @Test func testEncodePad1() {
         let bytes: [UInt8] = [
             0b10000100
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("GG======", data.base32EncodedString())
+        #expect("GG======" == data.base32EncodedString())
     }
 
-    func testEncodePad2() {
+    @Test func testEncodePad2() {
         let bytes: [UInt8] = [
             0b10000100, 0b00100001
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("GGGG====", data.base32EncodedString())
+        #expect("GGGG====" == data.base32EncodedString())
     }
 
-    func testEncodePad3() {
+    @Test func testEncodePad3() {
         let bytes: [UInt8] = [
             0b10000100, 0b00100001, 0b00001000
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("GGGGG===", data.base32EncodedString())
+        #expect("GGGGG===" == data.base32EncodedString())
     }
 
-    func testEncodePad4() {
+    @Test func testEncodePad4() {
         let bytes: [UInt8] = [
             0b10000100, 0b00100001, 0b00001000, 0b01000010
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("GGGGGGG=", data.base32EncodedString())
+        #expect("GGGGGGG=" == data.base32EncodedString())
     }
 
-    func testEncodeNoPad() {
+    @Test func testEncodeNoPad() {
         let bytes: [UInt8] = [
             0b10000100
         ]
         let data = Data(bytes)
 
-        XCTAssertEqual("GG", data.base32EncodedString(padding: false))
+        #expect("GG" == data.base32EncodedString(padding: false))
     }
 
     // MARK: -
     // MARK: Decode
 
-    func testDecodeBase32() {
+    @Test func testDecodeBase32() {
         let expected: [UInt8] = [
             0x00, 0x00, 0x00, 0x00, 0x01, 0x68, 0x3D, 0xD4, 0x19, 0x86,
             0xFE, 0xB3, 0xF9, 0x57, 0xAF, 0x8B, 0x6F, 0x46, 0x79, 0x77
@@ -155,11 +160,11 @@ final class Base32Tests: XCTestCase {
         let base32String = "00000001D0YX86C6ZTSZJNXFHDQMCYBQ"
         let data = Data(base32Encoded: base32String)
 
-        XCTAssertNotNil(data)
-        XCTAssertEqual(expected, Array(data!))
+        #expect(nil != data)
+        #expect(expected == Array(data!))
     }
 
-    func testDecodeTable() {
+    @Test func testDecodeTable() {
         let table: [Character: UInt8] = [
             "0": 0x00, "O": 0x00, "o": 0x00,
             "1": 0x01, "I": 0x01, "i": 0x01, "L": 0x01, "l": 0x01,
@@ -197,32 +202,31 @@ final class Base32Tests: XCTestCase {
 
         for (char, value) in table {
             let data = Data(base32Encoded: String(char) + "0")
-            XCTAssertNotNil(data)
-            XCTAssertEqual(1, data!.count)
-            XCTAssertEqual(value << 3, data![0])
+            #expect(nil != data)
+            #expect(1 == data!.count)
+            #expect(value << 3 == data![0])
         }
     }
 
-    func testDecodeInvalidCharacter() {
+    @Test func testDecodeInvalidCharacter() {
         let invalidCharacters = ["U", "u", "*", "~", "$", "="]
 
         for char in invalidCharacters {
             let data = Data(base32Encoded: char + "0")
-            XCTAssertNil(data)
+            #expect(nil == data)
         }
     }
 
-    func testDecodePadding() {
+    @Test func testDecodePadding() {
         let data = Data(base32Encoded: "AM======")
-        XCTAssertNotNil(data)
-        XCTAssertEqual(1, data!.count)
-        XCTAssertEqual(0b01010101, data![0])
+        #expect(nil != data)
+        #expect(1 == data!.count)
+        #expect(0b01010101 == data![0])
     }
 
-    func testDecodeIncorrectLength() {
+    @Test func testDecodeIncorrectLength() {
         let data = Data(base32Encoded: "0")
-        XCTAssertNil(data)
+        #expect(nil == data)
     }
 
 }
-#endif

--- a/Tests/ULIDTests/ULIDTesting.swift
+++ b/Tests/ULIDTests/ULIDTesting.swift
@@ -65,7 +65,7 @@ struct ULIDTests {
         ]
         
         let actual2 = ULID(timestamp: timestamp, randomPartData: Data(uuidTooBigSize))!
-        #expect(timestamp == actual.timestamp)
+        #expect(timestamp == actual2.timestamp)
         
         #expect(0x01 == actual2.ulid.6)
         #expect(0x68 == actual2.ulid.7)

--- a/Tests/ULIDTests/ULIDTesting.swift
+++ b/Tests/ULIDTests/ULIDTesting.swift
@@ -5,12 +5,17 @@
 //  Created by Yasuhiro Hatta on 2019/01/11.
 //  Copyright © 2019 yaslab. All rights reserved.
 //
-#if !os(Android)
-import XCTest
+//  Adapted for Amethyst Vein
+//
+//  copied at https://github.com/yaslab/ULID.swift/tree/15c21a2f4a6d27f65df2468c5338c949ae857903
+
+import Foundation
+import Testing
 import ULID
 
-final class ULIDTests: XCTestCase {
-
+@Suite
+struct ULIDTests {
+    @Test
     func testGenerateTimestamp() {
         let expected: [UInt8] = [
             0x01, 0x68, 0x3D, 0x17, 0x73, 0x09, 0xE5
@@ -19,20 +24,21 @@ final class ULIDTests: XCTestCase {
         let timestamp = Date(timeIntervalSince1970: 1547213173.513)
         let actual = ULID(timestamp: timestamp)
 
-        XCTAssertEqual(expected[0], actual.ulid.0)
-        XCTAssertEqual(expected[1], actual.ulid.1)
-        XCTAssertEqual(expected[2], actual.ulid.2)
-        XCTAssertEqual(expected[3], actual.ulid.3)
-        XCTAssertEqual(expected[4], actual.ulid.4)
-        XCTAssertEqual(expected[5], actual.ulid.5)
+        #expect(expected[0] == actual.ulid.0)
+        #expect(expected[1] == actual.ulid.1)
+        #expect(expected[2] == actual.ulid.2)
+        #expect(expected[3] == actual.ulid.3)
+        #expect(expected[4] == actual.ulid.4)
+        #expect(expected[5] == actual.ulid.5)
 
-        XCTAssertEqual(timestamp, actual.timestamp)
+        #expect(timestamp == actual.timestamp)
 
-        XCTAssertEqual(Array(expected.prefix(6)), Array(actual.ulidData.prefix(6)))
+        #expect(Array(expected.prefix(6)) == Array(actual.ulidData.prefix(6)))
 
-        XCTAssertEqual("01D0YHEWR9", actual.ulidString.prefix(10))
+        #expect("01D0YHEWR9" == actual.ulidString.prefix(10))
     }
     
+    @Test
     func testGenerateTimestampAndRandomnes(){
         let timestamp = Date(timeIntervalSince1970: 1547213173.513)
         let uuidCorrectSize: [UInt8] = [
@@ -40,20 +46,18 @@ final class ULIDTests: XCTestCase {
         ]
         
         let actual = ULID(timestamp: timestamp, randomPartData: Data(uuidCorrectSize))!
-        XCTAssertEqual(timestamp, actual.timestamp)
+        #expect(timestamp == actual.timestamp)
         
-        XCTAssertEqual(0x01, actual.ulid.6)
-        XCTAssertEqual(0x68, actual.ulid.7)
-        XCTAssertEqual(0x3D, actual.ulid.8)
-        XCTAssertEqual(0x17, actual.ulid.9)
-        XCTAssertEqual(0x73, actual.ulid.10)
-        XCTAssertEqual(0x09, actual.ulid.11)
-        XCTAssertEqual(0x69, actual.ulid.12)
-        XCTAssertEqual(0xF4, actual.ulid.13)
-        XCTAssertEqual(0xA2, actual.ulid.14)
-        XCTAssertEqual(0xB1, actual.ulid.15)
-
-        
+        #expect(0x01 == actual.ulid.6)
+        #expect(0x68 == actual.ulid.7)
+        #expect(0x3D == actual.ulid.8)
+        #expect(0x17 == actual.ulid.9)
+        #expect(0x73 == actual.ulid.10)
+        #expect(0x09 == actual.ulid.11)
+        #expect(0x69 == actual.ulid.12)
+        #expect(0xF4 == actual.ulid.13)
+        #expect(0xA2 == actual.ulid.14)
+        #expect(0xB1 == actual.ulid.15)
         
         //Test if initializer discards bytes beyond 10 bytes
         let uuidTooBigSize: [UInt8] = [
@@ -61,60 +65,63 @@ final class ULIDTests: XCTestCase {
         ]
         
         let actual2 = ULID(timestamp: timestamp, randomPartData: Data(uuidTooBigSize))!
-        XCTAssertEqual(timestamp, actual.timestamp)
+        #expect(timestamp == actual.timestamp)
         
-        XCTAssertEqual(0x01, actual2.ulid.6)
-        XCTAssertEqual(0x68, actual2.ulid.7)
-        XCTAssertEqual(0x3D, actual2.ulid.8)
-        XCTAssertEqual(0x17, actual2.ulid.9)
-        XCTAssertEqual(0x73, actual2.ulid.10)
-        XCTAssertEqual(0x09, actual2.ulid.11)
-        XCTAssertEqual(0x69, actual2.ulid.12)
-        XCTAssertEqual(0xF4, actual2.ulid.13)
-        XCTAssertEqual(0xA2, actual2.ulid.14)
-        XCTAssertEqual(0xB1, actual2.ulid.15)
-        
+        #expect(0x01 == actual2.ulid.6)
+        #expect(0x68 == actual2.ulid.7)
+        #expect(0x3D == actual2.ulid.8)
+        #expect(0x17 == actual2.ulid.9)
+        #expect(0x73 == actual2.ulid.10)
+        #expect(0x09 == actual2.ulid.11)
+        #expect(0x69 == actual2.ulid.12)
+        #expect(0xF4 == actual2.ulid.13)
+        #expect(0xA2 == actual2.ulid.14)
+        #expect(0xB1 == actual2.ulid.15)
         
         let uuidTooSmallSize: [UInt8] = [
             0x01, 0x68, 0x3D, 0x17, 0x73,
         ]
         
-        XCTAssertNil(ULID(timestamp: timestamp, randomPartData: Data(uuidTooSmallSize)))
+        #expect(nil == ULID(timestamp: timestamp, randomPartData: Data(uuidTooSmallSize)))
     }
 
+    @Test
     func testGenerateRandomness() {
         let timestamp = Date(timeIntervalSince1970: 1547213173.513)
         var generator = MockRandomNumberGenerator(value: 0x1122334455667788)
         let actual = ULID(timestamp: timestamp, generator: &generator)
 
-        XCTAssertEqual(timestamp, actual.timestamp)
+        #expect(timestamp == actual.timestamp)
 
-        XCTAssertEqual(0x77, actual.ulid.6)
-        XCTAssertEqual(0x88, actual.ulid.7)
-        XCTAssertEqual(0x11, actual.ulid.8)
-        XCTAssertEqual(0x22, actual.ulid.9)
-        XCTAssertEqual(0x33, actual.ulid.10)
-        XCTAssertEqual(0x44, actual.ulid.11)
-        XCTAssertEqual(0x55, actual.ulid.12)
-        XCTAssertEqual(0x66, actual.ulid.13)
-        XCTAssertEqual(0x77, actual.ulid.14)
-        XCTAssertEqual(0x88, actual.ulid.15)
+        #expect(0x77 == actual.ulid.6)
+        #expect(0x88 == actual.ulid.7)
+        #expect(0x11 == actual.ulid.8)
+        #expect(0x22 == actual.ulid.9)
+        #expect(0x33 == actual.ulid.10)
+        #expect(0x44 == actual.ulid.11)
+        #expect(0x55 == actual.ulid.12)
+        #expect(0x66 == actual.ulid.13)
+        #expect(0x77 == actual.ulid.14)
+        #expect(0x88 == actual.ulid.15)
     }
 
+    @Test
     func testParseULIDString() {
         let expected = "01D0YHEWR9WMPY4NNTPK1MR1TQ"
 
         let actual = ULID(ulidString: expected)
 
-        XCTAssertNotNil(actual)
-        XCTAssertEqual(expected, actual!.ulidString)
+        #expect(nil != actual)
+        #expect(expected == actual!.ulidString)
     }
 
+    @Test
     func testParseULIDStringError() {
         let zero = ""
-        XCTAssertNil(ULID(ulidString: zero))
+        #expect(nil == ULID(ulidString: zero))
     }
 
+    @Test
     func testParseULIDData() {
         let expected: [UInt8] = [
             0x01, 0x68, 0x3D, 0x17, 0x73, 0x09, 0xE5, 0x2D,
@@ -123,89 +130,101 @@ final class ULIDTests: XCTestCase {
 
         let actual = ULID(ulidData: Data(expected))
 
-        XCTAssertNotNil(actual)
-        XCTAssertEqual(expected, Array(actual!.ulidData))
+        #expect(nil != actual)
+        #expect(expected == Array(actual!.ulidData))
     }
 
+    @Test
     func testParseULIDDataError() {
         let zero = Data()
-        XCTAssertNil(ULID(ulidData: zero))
+        #expect(nil == ULID(ulidData: zero))
     }
 
+    @Test
     func testULIDDataLength() {
         let ulid = ULID()
-        XCTAssertEqual(16, ulid.ulidData.count)
+        #expect(16 == ulid.ulidData.count)
     }
 
+    @Test
     func testULIDStringLength() {
         let ulid = ULID()
-        XCTAssertEqual(26, ulid.ulidString.count)
+        #expect(26 == ulid.ulidString.count)
     }
 
+    @Test
     func testHashable1() {
         // Note: Hash values are not guaranteed to be equal across different executions.
         let ulid1 = ULID()
         let ulid2 = ULID(ulid: ulid1.ulid)
-        XCTAssertEqual(ulid1.hashValue, ulid2.hashValue)
+        #expect(ulid1.hashValue == ulid2.hashValue)
     }
 
+    @Test
     func testHashable2() {
         let timestamp = Date(timeIntervalSince1970: 1547213173.513)
 
         let ulid1 = ULID(timestamp: timestamp)
         let ulid2 = ULID(timestamp: timestamp)
 
-        XCTAssertNotEqual(ulid1.hashValue, ulid2.hashValue)
+        #expect(ulid1.hashValue != ulid2.hashValue)
     }
 
+    @Test
     func testHashable3() {
         let ulid1 = ULID()
         let ulid2 = ULID()
         let map = [ulid1: 1, ulid2: 2]
 
-        XCTAssertEqual(1, map[ulid1]!)
-        XCTAssertEqual(2, map[ulid2]!)
+        #expect(1 == map[ulid1]!)
+        #expect(2 == map[ulid2]!)
     }
 
+    @Test
     func testEquatable1() {
         let timestamp = Date(timeIntervalSince1970: 1547213173.513)
 
         let ulid1 = ULID(timestamp: timestamp)
         let ulid2 = ULID(ulid: ulid1.ulid)
 
-        XCTAssertEqual(ulid1, ulid2)
+        #expect(ulid1 == ulid2)
     }
 
+    @Test
     func testEquatable2() {
         let timestamp = Date(timeIntervalSince1970: 1547213173.513)
 
         let ulid1 = ULID(timestamp: timestamp)
         let ulid2 = ULID(timestamp: timestamp)
 
-        XCTAssertNotEqual(ulid1, ulid2)
+        #expect(ulid1 != ulid2)
     }
 
+    @Test
     func testComparable1() {
         let lhs = ULID(ulid: (1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
         let rhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
-        XCTAssertFalse(lhs < rhs)
-        XCTAssertTrue(lhs > rhs)
+        #expect(!(lhs < rhs))
+        #expect(lhs > rhs)
     }
 
+    @Test
     func testComparable2() {
         let lhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
         let rhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
-        XCTAssertFalse(lhs < rhs)
-        XCTAssertTrue(lhs > rhs)
+        #expect(!(lhs < rhs))
+        #expect(lhs > rhs)
     }
 
+    @Test
     func testComparable3() {
         let lhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
         let rhs = ULID(ulid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
-        XCTAssertTrue(lhs < rhs)
-        XCTAssertFalse(lhs > rhs)
+        #expect(lhs < rhs)
+        #expect(!(lhs > rhs))
     }
 
+    @Test
     func testComparable4() {
         let now = Date()
         let ulid0 = ULID(timestamp: now.addingTimeInterval(-120))
@@ -215,22 +234,24 @@ final class ULIDTests: XCTestCase {
         let ulid4 = ULID(timestamp: now.addingTimeInterval(120))
         let sorted = [ulid2, ulid0, ulid3, ulid4, ulid1].sorted()
 
-        XCTAssertEqual(ulid0, sorted[0])
-        XCTAssertEqual(ulid1, sorted[1])
-        XCTAssertEqual(ulid2, sorted[2])
-        XCTAssertEqual(ulid3, sorted[3])
-        XCTAssertEqual(ulid4, sorted[4])
+        #expect(ulid0 == sorted[0])
+        #expect(ulid1 == sorted[1])
+        #expect(ulid2 == sorted[2])
+        #expect(ulid3 == sorted[3])
+        #expect(ulid4 == sorted[4])
     }
 
+    @Test
     func testCustomStringConvertible() {
         let ulid = ULID()
-        XCTAssertEqual(ulid.ulidString, ulid.description)
+        #expect(ulid.ulidString == ulid.description)
     }
 
     struct CodableModel: Codable {
         let ulid: ULID
     }
 
+    @Test
     func testDecodable() {
         let ulidString = "01D0YHEWR9WMPY4NNTPK1MR1TQ"
         let json = """
@@ -239,12 +260,13 @@ final class ULIDTests: XCTestCase {
         do {
             let decoder = JSONDecoder()
             let model = try decoder.decode(CodableModel.self, from: json.data(using: .utf8)!)
-            XCTAssertEqual(ulidString, model.ulid.ulidString)
+            #expect(ulidString == model.ulid.ulidString)
         } catch {
-            XCTFail("\(error)")
+            Issue.record(error)
         }
     }
 
+    @Test
     func testDecodableError() {
         let json = """
             { "ulid" : "" }
@@ -252,14 +274,15 @@ final class ULIDTests: XCTestCase {
         do {
             let decoder = JSONDecoder()
             _ = try decoder.decode(CodableModel.self, from: json.data(using: .utf8)!)
-            XCTFail()
+            Issue.record()
         } catch DecodingError.dataCorrupted {
             // Success
         } catch {
-            XCTFail()
+            Issue.record()
         }
     }
 
+    @Test
     func testEncodable() {
         let ulidString = "01D0YHEWR9WMPY4NNTPK1MR1TQ"
         let expected = """
@@ -269,14 +292,15 @@ final class ULIDTests: XCTestCase {
             let encoder = JSONEncoder()
             let model = CodableModel(ulid: ULID(ulidString: ulidString)!)
             let actual = try String(data: encoder.encode(model), encoding: .utf8)
-            XCTAssertEqual(expected, actual)
+            #expect(expected == actual)
         } catch {
-            XCTFail("\(error)")
+            Issue.record(error)
         }
     }
 
+    @Test
     func testMemorySize() {
-        XCTAssertEqual(16, MemoryLayout<ULID>.size)
+        #expect(16 == MemoryLayout<ULID>.size)
     }
 
 }
@@ -295,4 +319,3 @@ private struct MockRandomNumberGenerator: RandomNumberGenerator {
     }
 
 }
-#endif


### PR DESCRIPTION
Resolves https://github.com/amethystsoft/vein/issues/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the copied ULID test suites to use Swift Testing instead of XCTest, migrating both `Tests/ULIDTests/Data+Base32Tests.swift` and the wider `Tests/ULIDTests/ULIDTesting.swift` suite from `XCTestCase` to `@Suite`/`@Test` with `#expect` assertions. The change removes the previous `#if !os(Android)` gating, keeps the existing encoded/decoded test coverage and expected values, and updates failure/error handling to Swift Testing conventions (including `Issue.record(...)` where appropriate).

Also added copy-attribution header comment lines to the ULID source files. In `Sources/ULID/ULID.swift`, the ULID initialization logic was refactored to simplify random-part derivation and to construct the internal byte representation directly (removing the prior buffer-writing approach and related endianness conversions), aligning with the commit intent to address the timestamp-related test logic and potentially the Android CI test failure described in issue `#36`.

A particularly good aspect of this PR is that it modernizes the test infrastructure without reducing coverage: the test cases and expected vectors remain the same while the assertion framework and failure reporting are updated to be consistent across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->