### PR TITLE
fixed tests in release and resolved 2 tsan issues

### DIFF
--- a/.github/workflows/swift-test-all-release.yml
+++ b/.github/workflows/swift-test-all-release.yml
@@ -1,0 +1,41 @@
+name: Swift Test release
+
+on:
+  workflow_dispatch:
+jobs:
+  linux-android:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: "Test Swift Package on Android"
+        uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
+        with:
+          swift-version: 'nightly-main'
+          # Ubuntu runners low on space causes the emulator to fail to install
+          free-disk-space: true
+          test-env: SHOULD_DISABLE_ENCRYPTION=1
+          swift-configuration: release
+  macos:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: Test VeinCore
+        run: ./Scripts/tsan-test-release.sh
+      - name: Test VeinSwiftUI
+        run: TEST_SWIFTUI=1 ./Scripts/tsan-test-release.sh
+  linux:
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    container:
+      image: swift:6.3.2-noble
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: Test
+        # Disable encryption for testing purposes if needed
+        run: ./Scripts/tsan-test-release.sh

--- a/.github/workflows/swift-test-all-release.yml
+++ b/.github/workflows/swift-test-all-release.yml
@@ -2,6 +2,10 @@ name: Swift Test release
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   linux-android:
     runs-on: ubuntu-24.04

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+
 jobs:
   linux-android:
     runs-on: ubuntu-24.04

--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   linux:

--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   linux:

--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
+    
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/Scripts/tsan-test-release.sh
+++ b/Scripts/tsan-test-release.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+TSAN_OPTIONS="suppressions=tsan_suppressions.txt" SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts --sanitize=thread -c release

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -40,6 +40,8 @@ public protocol PersistentModel: AnyObject, Sendable {
     
     var _isDeleted: Bool? { get set }
     
+    var _context: Vein.Atomic<Vein.ManagedObjectContext?> { get }
+    
     init(id: ULID, fields: [String: SQLiteValue])
 }
 
@@ -47,6 +49,15 @@ extension PersistentModel {
     public static var typeIdentifier: ObjectIdentifier { ObjectIdentifier(Self.self) }
     public var typeIdentifier: ObjectIdentifier { ObjectIdentifier(Self.self) }
     public func _getSchema() -> String { Self.schema }
+    
+    public var context: ManagedObjectContext? {
+        get {
+            _context.value
+        }
+        set {
+            _context.value = newValue
+        }
+    }
     
     public func extractPrimitiveState() -> PrimitiveState {
         var data = [String: Any]()

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -10,7 +10,6 @@ public protocol PersistentModel: AnyObject, Sendable {
     /// Gets  used to reference models in relationships.
     /// Immutable after insertion into the context.
     var id: ULID { get set }
-    var context: ManagedObjectContext? { get set }
     
     /// Whether a model is prepared to be deleted.
     ///

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+SingleInstance.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+SingleInstance.swift
@@ -12,19 +12,20 @@ extension ManagedObjectContext {
 }
 
 nonisolated final class ThreadSafeIdentityMap {
-    private var cache = Atomic([ObjectIdentifier: [ULID: WeakModel]]())
+    private let lock = NSLock()
+    private var cache = [ObjectIdentifier: [ULID: WeakModel]]()
     
     func getAll<T: PersistentModel>(of type: T.Type) -> [T] {
-        return
-            cache
-            .value[type.typeIdentifier]?
-            .values
-            .compactMap { $0.wrappedValue as? T } ?? []
+        return lock.withLock {
+            cache[type.typeIdentifier]?
+                .values
+                .compactMap { $0.wrappedValue as? T } ?? []
+        }
     }
     
     func removeAll<T: PersistentModel>(of type: T.Type) {
-        cache.mutate { value in
-            value[type.typeIdentifier] = nil
+        lock.withLock {
+            cache[type.typeIdentifier] = nil
         }
     }
     
@@ -37,15 +38,19 @@ nonisolated final class ThreadSafeIdentityMap {
     }
     
     func getTrackedCount() -> Int {
-        cache.value.reduce(0, {
-            $0 + $1.value.count(where: { _, value in
-                !value.isDeallocated
+        lock.withLock {
+            cache.reduce(0, {
+                $0 + $1.value.count(where: { _, value in
+                    !value.isDeallocated
+                })
             })
-        })
+        }
     }
     
     func startTracking<T: PersistentModel>(_ object: T) {
-        track(object)
+        lock.withLock {
+            cache[object.typeIdentifier, default: [:]][object.id] = WeakModel(wrappedValue: object)
+        }
     }
     
     func batched<T: PersistentModel>(
@@ -54,19 +59,20 @@ nonisolated final class ThreadSafeIdentityMap {
             (T) -> Void
         ) throws -> Void
     ) rethrows {
-        try block(getTracked, track)
-    }
-    
-    @inline(__always)
-    private func track<T: PersistentModel>(_ object: T) {
-        cache.mutate { cache in
-            cache[object.typeIdentifier, default: [:]][object.id] = WeakModel(wrappedValue: object)
+        try lock.withLock {
+            try block(
+                { type, id in self.get(type.typeIdentifier, id: id) },
+                { object in self.track(object) }
+            )
         }
     }
     
-    @inline(__always)
+    private func track<T: PersistentModel>(_ object: T) {
+        cache[object.typeIdentifier, default: [:]][object.id] = WeakModel(wrappedValue: object)
+    }
+    
     private func get<T: PersistentModel>(_ type: ObjectIdentifier, id: ULID) -> T? {
-        cache.value[type]?[id]?.wrappedValue as? T
+        cache[type]?[id]?.wrappedValue as? T
     }
     
     func remove<T: PersistentModel>(_ type: T.Type, id: ULID) {
@@ -74,13 +80,13 @@ nonisolated final class ThreadSafeIdentityMap {
     }
     
     func remove(_ type: ObjectIdentifier, id: ULID) {
-        cache.mutate { contents in
-            _ = contents[type]?.removeValue(forKey: id)
+        lock.withLock {
+            _ = cache[type]?.removeValue(forKey: id)
         }
     }
     
     func compact() {
-        cache.mutate { cache in
+        lock.withLock {
             for (type, var references) in cache {
                 references = references.filter { _, box in !box.isDeallocated }
                 if references.isEmpty {

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+SingleInstance.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+SingleInstance.swift
@@ -30,11 +30,15 @@ nonisolated final class ThreadSafeIdentityMap {
     }
     
     func getTracked<T: PersistentModel>(_ type: T.Type, id: ULID) -> T? {
-        get(type.typeIdentifier, id: id)
+        lock.withLock {
+            get(type.typeIdentifier, id: id)
+        }
     }
     
     func getTracked<T: PersistentModel>(_ type: ObjectIdentifier, id: ULID) -> T? {
-        get(type, id: id)
+        lock.withLock {
+            get(type, id: id)
+        }
     }
     
     func getTrackedCount() -> Int {

--- a/Sources/VeinCore/ModelMacro.swift
+++ b/Sources/VeinCore/ModelMacro.swift
@@ -1,6 +1,6 @@
 @_exported import Vein
 
-@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation), named(_updatedAt), named(_clientID), named(_isDeleted))
+@attached(member, names: named(init), named(id), named(_setupFields), named(_context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation), named(_updatedAt), named(_clientID), named(_isDeleted))
 @attached(extension, conformances: PersistentModel, Sendable, names: named(version), named(schema))
 @attached(memberAttribute)
 public macro Model() = #externalMacro(

--- a/Sources/VeinSwiftUI/ModelMacro.swift
+++ b/Sources/VeinSwiftUI/ModelMacro.swift
@@ -2,7 +2,7 @@
 @_exported import Combine
 import Vein
 
-@attached(member, names: named(init), named(id), named(_setupFields), named(context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation), named(_updatedAt), named(_clientID), named(_isDeleted))
+@attached(member, names: named(init), named(id), named(_setupFields), named(_context), named(_getSchema), named(_fields), named(_relationships), named(_fieldInformation), named(objectWillChange), named(_key), named(_satisfiesConstraint), named(notifyOfChanges), named(_isPreparedForDeletion), named(_inverseFields), named(_observers), named(_predicateInformation), named(_updatedAt), named(_clientID), named(_isDeleted))
 @attached(extension, conformances: PersistentModel, Sendable, ObservableObject, names: named(version), named(schema))
 @attached(memberAttribute)
 public macro Model() = #externalMacro(

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -72,7 +72,7 @@ struct MacrosTests {
                     self._id.model = self
                 }
             
-                var context: Vein.ManagedObjectContext? = nil
+                let _context = Vein.Atomic<Vein.ManagedObjectContext?>(nil)
             
                 /// Whether a model is prepared to be deleted.
                 ///
@@ -193,7 +193,7 @@ struct MacrosTests {
                     self._id.model = self
                 }
             
-                var context: Vein.ManagedObjectContext? = nil
+                let _context = Vein.Atomic<Vein.ManagedObjectContext?>(nil)
             
                 /// Whether a model is prepared to be deleted.
                 ///
@@ -327,7 +327,7 @@ struct MacrosTests {
                     self._id.model = self
                 }
             
-                var context: Vein.ManagedObjectContext? = nil
+                let _context = Vein.Atomic<Vein.ManagedObjectContext?>(nil)
             
                 /// Whether a model is prepared to be deleted.
                 ///
@@ -447,7 +447,7 @@ struct MacrosTests {
                     self._id.model = self
                 }
             
-                var context: Vein.ManagedObjectContext? = nil
+                let _context = Vein.Atomic<Vein.ManagedObjectContext?>(nil)
             
                 /// Whether a model is prepared to be deleted.
                 ///

--- a/Tests/VeinTests/Migrations/DetermineMigrationStage/NoMigrationForOutdatedModelVersion.swift
+++ b/Tests/VeinTests/Migrations/DetermineMigrationStage/NoMigrationForOutdatedModelVersion.swift
@@ -38,7 +38,7 @@ extension MigrationTests {
                     version
                 ) = error
             {
-                #expect("\(migration)" == "\(MigrationPlan.self)")
+                #expect("\(migration)" == "MigrationPlan")
                 #expect(version == Version0_0_1.version)
                 return
             }

--- a/Tests/VeinTests/Migrations/DetermineMigrationStage/NoSchemaMatchingVersion.swift
+++ b/Tests/VeinTests/Migrations/DetermineMigrationStage/NoSchemaMatchingVersion.swift
@@ -38,7 +38,7 @@ extension MigrationTests {
                     version
                 ) = error
             {
-                #expect("\(migration)" == "\(MigrationPlan.self)")
+                #expect("\(migration)" == "MigrationPlan")
                 #expect(version == Version0_0_1.version)
                 return
             }

--- a/Tests/VeinTests/Migrations/ModelsUnhandledAfterMigration.swift
+++ b/Tests/VeinTests/Migrations/ModelsUnhandledAfterMigration.swift
@@ -39,8 +39,8 @@ extension MigrationTests {
                     schemas
                 ) = error
             {
-                #expect("\(origin)" == "\(Version0_0_1.self)")
-                #expect("\(destination)" == "\(Version0_0_2.self)")
+                #expect("\(origin)" == "Version0_0_1")
+                #expect("\(destination)" == "Version0_0_2")
                 #expect(schemas == [Version0_0_1.BasicModel.schema])
                 return
             }

--- a/Tests/VeinTests/Migrations/VersionedSchemaIsNotPartOfSchemaMigrationPlan.swift
+++ b/Tests/VeinTests/Migrations/VersionedSchemaIsNotPartOfSchemaMigrationPlan.swift
@@ -27,8 +27,8 @@ extension MigrationTests {
                     migration
                 ) = error
             {
-                #expect("\(schema)" == "\(Version0_0_2.self)")
-                #expect("\(migration)" == "\(MigrationPlan.self)")
+                #expect("\(schema)" == "Version0_0_2")
+                #expect("\(migration)" == "MigrationPlan")
                 return
             }
             Issue.record("Thrown error does not match expectations: \(error.errorDescription)")

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -154,7 +154,7 @@ public func _setupFields() {
     \(fieldSetup)
 }
 
-var context: Vein.ManagedObjectContext? = nil
+let _context = Vein.Atomic<Vein.ManagedObjectContext?>(nil)
 
 /// Whether a model is prepared to be deleted.
 ///


### PR DESCRIPTION
resolves https://github.com/amethystsoft/vein/issues/50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed release-mode test failures caused by string interpolation differences by switching affected expectations to stable literal values, and updated model macro expansion to generate atomic `_context` storage instead of a mutable `context` property.

Also improved thread-safety in `ThreadSafeIdentityMap` by replacing atomic cache mutation with explicit locking, and added release-mode TSAN test coverage/workflows for Android, macOS, and Linux.

Great job tightening both the test expectations and the generated model storage to make behavior more consistent across build modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->