### PR TITLE
attempt to fix ULID was not compiled for testing caused by separated release build

### DIFF
--- a/.github/workflows/swift-test-all-release.yml
+++ b/.github/workflows/swift-test-all-release.yml
@@ -21,6 +21,7 @@ jobs:
           free-disk-space: true
           test-env: SHOULD_DISABLE_ENCRYPTION=1
           swift-configuration: release
+          swift-build-flags: --enable-testing
   macos:
     runs-on: macos-26
     steps:


### PR DESCRIPTION
Swift android action first builds then tests afaik, so when building in release we need to explicitly tell the compiler to build for testing