### PR TITLE
Added configurable logging

### DIFF
--- a/Sources/Vein/Logging/LogConfiguration.swift
+++ b/Sources/Vein/Logging/LogConfiguration.swift
@@ -1,0 +1,57 @@
+public struct LogConfiguration: Sendable {
+    /// Whether to log every sql query.
+    public var sqlQueries: Bool
+    /// Whether to log when a potential data corruption is found.
+    public var potentialDataCorruption: Bool
+    /// Whether to log when a potential data corruption is found during a migration.
+    public var potentialDataCorruptionInMigration: Bool
+    /// Whether to log when a result is empty but results were expected.
+    public var unexpectedlyEmptyResults: Bool
+    /// Whether to log when a an error occurs during a cascading deletion.
+    public var errorWhileCascadeDeletion: Bool
+    /// Whether to log when it was attempted to mutate a primary key on a managed model.
+    public var primaryKeyMutation: Bool
+    /// Whether to log ``ManagedObjectContext`` errors.
+    public var modelContextErrors: Bool
+    
+    public init(
+        sqlQueries: Bool,
+        potentialDataCorruption: Bool,
+        potentialDataCorruptionInMigration: Bool,
+        unexpectedlyEmptyResults: Bool,
+        errorWhileCascadeDeletion: Bool,
+        primaryKeyMutation: Bool,
+        modelContextErrors: Bool
+    ) {
+        self.sqlQueries = sqlQueries
+        self.potentialDataCorruption = potentialDataCorruption
+        self.potentialDataCorruptionInMigration = potentialDataCorruptionInMigration
+        self.unexpectedlyEmptyResults = unexpectedlyEmptyResults
+        self.errorWhileCascadeDeletion = errorWhileCascadeDeletion
+        self.primaryKeyMutation = primaryKeyMutation
+        self.modelContextErrors = modelContextErrors
+    }
+    
+    public static var debug: Self {
+        LogConfiguration(
+            sqlQueries: false,
+            potentialDataCorruption: true,
+            potentialDataCorruptionInMigration: true,
+            unexpectedlyEmptyResults: true,
+            errorWhileCascadeDeletion: true,
+            primaryKeyMutation: true,
+            modelContextErrors: true
+        )
+    }
+    public static var release: Self {
+        LogConfiguration(
+            sqlQueries: false,
+            potentialDataCorruption: true,
+            potentialDataCorruptionInMigration: true,
+            unexpectedlyEmptyResults: false,
+            errorWhileCascadeDeletion: false,
+            primaryKeyMutation: false,
+            modelContextErrors: true
+        )
+    }
+}

--- a/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
@@ -92,9 +92,12 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
                 return []
             }
             if case .unexpectedlyEmptyResult = error {
-                Self.logger.warning("Unexpectedly empty result for \(T.self)")
+                if context.modelContainer.logConfiguration.unexpectedlyEmptyResults {
+                    Self.logger.warning("Unexpectedly empty result for \(T.self)")
+                }
                 return []
             }
+            
             fatalError(error.localizedDescription)
         }
     }
@@ -293,7 +296,9 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
                     do {
                         try context.delete(target)
                     } catch {
-                        Self.logger.error("An error occurred while cascading deletion: \(error)")
+                        if context.modelContainer.logConfiguration.errorWhileCascadeDeletion {
+                            Self.logger.error("An error occurred while cascading deletion: \(error)")
+                        }
                     }
             }
         }

--- a/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
@@ -110,7 +110,9 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
                 return nil
             }
             if case .unexpectedlyEmptyResult = error {
-                Self.logger.warning("Unexpectedly empty result for \(T.self)")
+                if context.modelContainer.logConfiguration.unexpectedlyEmptyResults {
+                    Self.logger.warning("Unexpectedly empty result for \(T.self)")
+                }
                 return nil
             }
             fatalError(error.localizedDescription)
@@ -288,7 +290,9 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
                 do {
                     try context.delete(target)
                 } catch {
-                    Self.logger.error("An error occurred while cascading deletion: \(error)")
+                    if context.modelContainer.logConfiguration.errorWhileCascadeDeletion {
+                        Self.logger.error("An error occurred while cascading deletion: \(error)")
+                    }
                 }
         }
     }

--- a/Sources/Vein/Model/PropertyWrappers/PrimaryKeyWrapper.swift
+++ b/Sources/Vein/Model/PropertyWrappers/PrimaryKeyWrapper.swift
@@ -25,13 +25,15 @@ public class PrimaryKey: PersistedField, @unchecked Sendable {
         }
         set {
             lock.withLock {
-                if model?.context == nil {
-                    store = newValue
+                if let context = model?.context {
+                    if context.modelContainer.logConfiguration.primaryKeyMutation {
+                        PrimaryKey.logger.warning("""
+                        Attempted to mutate ID of inserted model with ID: \(store). \
+                        This is not supported.
+                        """)
+                    }
                 } else {
-                    PrimaryKey.logger.warning("""
-                    Attempted to mutate ID of inserted model with ID: \(store). \
-                    This is not supported.
-                    """)
+                    store = newValue
                 }
             }
         }

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Fetch.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Fetch.swift
@@ -13,6 +13,12 @@ extension ManagedObjectContext {
             fieldsToLoad.append(SQLExpression<String>("id"))
             let select = table.select(fieldsToLoad)
             
+            if modelContainer.logConfiguration.sqlQueries {
+                Self.logger.info(
+                    "Fetching \(T.self) with \nQuery: '\(select.expression.template)'\nBindings:\(select.expression.bindings)"
+                )
+            }
+            
             var models = [T]()
             
             var currentlyDeleted = [ULID: any PersistentModel]()
@@ -93,6 +99,12 @@ extension ManagedObjectContext {
         
         let table = Table(model._getSchema()).filter(SQLExpression<String>("id") == model.id.ulidString)
         let select = table.select(distinct: [field.fetchExpressible]).limit(1)
+        
+        if modelContainer.logConfiguration.sqlQueries {
+            Self.logger.info(
+                "Fetching \(field.instanceKey) of \(model._getSchema()) with \nQuery: '\(select.expression.template)'\nBindings:\(select.expression.bindings)"
+            )
+        }
         
         do {
             for row in try connection.prepare(select) {

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
@@ -12,7 +12,15 @@ extension ManagedObjectContext {
                     .sqliteSetter(key: $0.instanceKey)
             }
             
-            try connection.run(table.insert(values))
+            let insert = table.insert(values)
+            
+            if modelContainer.logConfiguration.sqlQueries {
+                Self.logger.info(
+                    "Inserting \(M.self) with \nQuery: '\(insert.expression.template)'\nBindings:\(insert.expression.bindings)"
+                )
+            }
+            
+            try connection.run(insert)
         } catch let error as ManagedObjectContextError { throw error }
         catch let error as SQLiteDB.Result {
             let parsed = error.parse()
@@ -46,6 +54,12 @@ extension ManagedObjectContext {
                         }
                 )
             
+            if modelContainer.logConfiguration.sqlQueries {
+                Self.logger.info(
+                    "Updating \(M.self) with \nQuery: '\(query.expression.template)'\nBindings:\(query.expression.bindings)"
+                )
+            }
+            
             try connection.run(
                 query
             )
@@ -63,8 +77,16 @@ extension ManagedObjectContext {
     
     nonisolated func _writeDelete(_ model: any PersistentModel) throws(MOCError) {
         let filter = Table(model._getSchema()).filter(SQLExpression<String>("id") == model.id.ulidString)
+        let query = filter.delete()
+        
+        if modelContainer.logConfiguration.sqlQueries {
+            Self.logger.info(
+                "Deleting \(model._getSchema()) with \nQuery: '\(query.expression.template)'\nBindings:\(query.expression.bindings)"
+            )
+        }
+        
         do {
-            try connection.run(filter.delete())
+            try connection.run(query)
             model.context = nil
             
             Task { @MainActor in
@@ -94,6 +116,11 @@ extension ManagedObjectContext {
     }
     
     package nonisolated func run(_ query: String) throws(ManagedObjectContextError) {
+        if modelContainer.logConfiguration.sqlQueries {
+            Self.logger.info(
+                "Running query '\(query)'"
+            )
+        }
         do {
             try connection.run(query)
         } catch let error as SQLiteDB.Result {

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
@@ -59,13 +59,17 @@ extension ManagedObjectContext {
                 sortedModels.append(target)
             } else {
                 if !isInMigration {
-                    Self.logger.warning(
-                        "Relationship ID mismatch for \(T.self). Potential data corruption."
-                    )
+                    if modelContainer.logConfiguration.potentialDataCorruption {
+                        Self.logger.warning(
+                            "Relationship ID mismatch for \(T.self). Potential data corruption."
+                        )
+                    }
                 } else {
-                    Self.logger.info(
-                        "[Migration] Relationship ID mismatch for \(T.self). Verify migration integrity if unexpected."
-                    )
+                    if modelContainer.logConfiguration.potentialDataCorruptionInMigration {
+                        Self.logger.info(
+                            "[Migration] Relationship ID mismatch for \(T.self). Verify migration integrity if unexpected."
+                        )
+                    }
                 }
             }
         }
@@ -83,6 +87,13 @@ extension ManagedObjectContext {
             var fieldsToLoad = eagerLoadedFields.map { $0.fetchExpressible }
             fieldsToLoad.append(SQLExpression<String>("id"))
             let select = table.select(distinct: fieldsToLoad)
+            
+            if modelContainer.logConfiguration.sqlQueries {
+                Self.logger.info(
+                    "Fetching \(T.self) with \nQuery: \(select.expression.template)\nBindings:\(select.expression.bindings)"
+                )
+            }
+            
             var models = [ULID: T]()
             
             var currentlyDeleted = [ULID: any PersistentModel]()

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -14,7 +14,7 @@ typealias Connection = SQLiteDB.Connection
 public actor ManagedObjectContext {
     public static let logger = Logger(label: "ManagedObjectContext")
     package nonisolated let connection: SQLiteDB.Connection
-    nonisolated unowned let modelContainer: ModelContainer
+    public nonisolated unowned let modelContainer: ModelContainer
     
     @TaskLocal static var isSettingInternalMetdata = false
     

--- a/Sources/Vein/ModelContext/ModelContainer.swift
+++ b/Sources/Vein/ModelContext/ModelContainer.swift
@@ -2,7 +2,7 @@ import Foundation
 import SQLiteDB
 
 public final class ModelContainer: @unchecked Sendable {
-    private let migration: SchemaMigrationPlan.Type
+    public let migration: SchemaMigrationPlan.Type
     private let path: String?
     
     // Only force unwrapped to count as initialized,
@@ -20,11 +20,19 @@ public final class ModelContainer: @unchecked Sendable {
     
     public let encryptionEnabled: Bool
     
+    public let logConfiguration: LogConfiguration
+    
     
     /// Manages the schema and storage for a Vein database.
     ///
-    /// - Parameter appID: A unique identifier used per-database to construct the keyring
+    /// - Parameters:
+    ///   - versionedSchema: The VersionedSchema you want to use models of.
+    ///   - migration: The MigrationPlan to use if migrations are necessary.
+    ///   - path: The path of the database file or nil for in memory.
+    ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
+    ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
     ///   underlying `KeyringAccess` library, typically set once per process or environment.
@@ -49,8 +57,18 @@ public final class ModelContainer: @unchecked Sendable {
         migration: SchemaMigrationPlan.Type,
         at path: String?,
         appID: String,
-        encryptionEnabled: Bool = true
+        encryptionEnabled: Bool = true,
+        logConfiguration: LogConfiguration? = nil
     ) throws(ManagedObjectContextError) {
+        if let logConfiguration {
+            self.logConfiguration = logConfiguration
+        } else {
+            #if DEBUG
+            self.logConfiguration = .debug
+            #else
+            self.logConfiguration = .release
+            #endif
+        }
         self.encryptionEnabled = encryptionEnabled
         self.appID = appID
         
@@ -101,8 +119,14 @@ public final class ModelContainer: @unchecked Sendable {
     
     /// Manages the schema and storage for a Vein database.
     ///
-    /// - Parameter appID: A unique identifier used per-database to construct the keyring
+    /// - Parameters:
+    ///   - versionedSchema: The VersionedSchema you want to use models of.
+    ///   - migration: The MigrationPlan to use if migrations are necessary.
+    ///   - connection: The existing connection to the database.
+    ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
+    ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
     ///   underlying `KeyringAccess` library, typically set once per process or environment.
@@ -127,8 +151,19 @@ public final class ModelContainer: @unchecked Sendable {
         migration: SchemaMigrationPlan.Type,
         connection: Connection,
         appID: String,
-        encryptionEnabled: Bool = true
+        encryptionEnabled: Bool = true,
+        logConfiguration: LogConfiguration? = nil
     ) throws(ManagedObjectContextError) {
+        if let logConfiguration {
+            self.logConfiguration = logConfiguration
+        } else {
+            #if DEBUG
+            self.logConfiguration = .debug
+            #else
+            self.logConfiguration = .release
+            #endif
+        }
+        
         self.encryptionEnabled = encryptionEnabled
         self.appID = appID
         

--- a/Sources/VeinSwiftUI/Query.swift
+++ b/Sources/VeinSwiftUI/Query.swift
@@ -83,7 +83,7 @@ package final class QueryObserver<M: PersistentModel>: ObservableObject, @unchec
             let initialResults = try context.fetchAll(predicate)
             self.results = initialResults
         } catch {
-            if context.modelContainer.logConfiguration.unexpectedlyEmptyResults {
+            if context.modelContainer.logConfiguration.modelContextErrors {
                 Self.logger.error("Failed to fetch initial query results: \(error.localizedDescription)")
             }
             self.results = []

--- a/Sources/VeinSwiftUI/Query.swift
+++ b/Sources/VeinSwiftUI/Query.swift
@@ -83,7 +83,9 @@ package final class QueryObserver<M: PersistentModel>: ObservableObject, @unchec
             let initialResults = try context.fetchAll(predicate)
             self.results = initialResults
         } catch {
-            Self.logger.error("Failed to fetch initial query results: \(error.localizedDescription)")
+            if context.modelContainer.logConfiguration.unexpectedlyEmptyResults {
+                Self.logger.error("Failed to fetch initial query results: \(error.localizedDescription)")
+            }
             self.results = []
         }
     }
@@ -169,6 +171,7 @@ public struct VeinContainer<Content: View>: View {
     @State private var isInitialized: Bool = false
     @State var error: Error?
     private let content: () -> Content
+    static var logger: Logger { Logger(label: "Vein.VeinContainer") }
     
     public init(@ViewBuilder content: @escaping () -> Content ) {
         self.content = content
@@ -199,7 +202,9 @@ public struct VeinContainer<Content: View>: View {
                             isInitialized = true
                         } catch {
                             self.error = error
-                            print(error.localizedDescription)
+                            if container.logConfiguration.modelContextErrors {
+                                Self.logger.error("An error occurred during migration of ModelContainer with version \(container.versionedSchema) and MigrationPlan \(container.migration): \(error.localizedDescription)")
+                            }
                         }
                     }
             }

--- a/Sources/VeinTesting/MigrationTester.swift
+++ b/Sources/VeinTesting/MigrationTester.swift
@@ -17,6 +17,7 @@ public struct MigrationTester {
     
     public func seed(
         version: VersionedSchema.Type,
+        logConfiguration: LogConfiguration? = nil,
         with block: (ManagedObjectContext) throws -> Void
     ) throws {
         let container = try ModelContainer(
@@ -24,7 +25,8 @@ public struct MigrationTester {
             migration: migrationPlan,
             at: containerPath,
             appID: "de.amethystsoft.vein.MigrationTests",
-            encryptionEnabled: ProcessInfo.shouldEnableEncryption
+            encryptionEnabled: ProcessInfo.shouldEnableEncryption,
+            logConfiguration: logConfiguration
         )
         try block(container.context)
     }


### PR DESCRIPTION
Resolves https://github.com/amethystsoft/vein/issues/46
I decided to go with configurable instead of plugging in a closure for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added configurable logging across the core model/container stack, replacing the prior closure-based direction with a simple `LogConfiguration` that lets callers opt into query logging and targeted diagnostics.

Highlights:
- Introduced `LogConfiguration` with presets for debug/release behavior.
- Added `logConfiguration` to `ModelContainer` with sensible defaults.
- Enabled conditional logging for SQL queries, migration issues, relationship mismatches, cascade deletion errors, primary key mutation attempts, and empty-result cases.
- Exposed `ModelContainer.migration` and `ManagedObjectContext.modelContainer` publicly to support the new logging access.
- Updated testing utilities to pass logging configuration through seeding.

One especially nice touch: the logging is now granular enough to reduce noise in normal runs while still making deep debugging much easier when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->