### PR TITLE
Added easy path for persisting RawRepresentable and Codable

### DIFF
--- a/Examples/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Examples/BasicExample/BasicExample/BasicExampleApp.swift
@@ -39,6 +39,11 @@ struct VeinTestEnvironmentApp: App {
     var body: some Scene {
         WindowGroup("VeinTest") {
             VeinContainer {
+                // This is displayed here to make debugging and looking at
+                // the db example easier.
+                // NEVER do this in prod.
+                Text(modelContainer.context.getDatabaseKey() ?? "no key")
+                    .textSelection(.enabled)
                 HStack {
                     ContentView()
                     #if !canImport(UIKit)

--- a/Examples/BasicExample/BasicExample/ContentView.swift
+++ b/Examples/BasicExample/BasicExample/ContentView.swift
@@ -31,7 +31,11 @@ struct ContentView: View {
                 print(context.trackedObjectCount)
             }
             Button("save changes") {
-                try? context.save()
+                do {
+                    try context.save()
+                } catch {
+                    print(error.localizedDescription)
+                }
             }
             Button("add one") {
                 do {

--- a/Examples/BasicExample/BasicExample/ModelTest.swift
+++ b/Examples/BasicExample/BasicExample/ModelTest.swift
@@ -56,31 +56,7 @@ enum TestMigration: SchemaMigrationPlan {
     }
 }
 
-nonisolated enum Group: String, Persistable, CaseIterable {
-    var asPersistentRepresentation: String {
-        self.rawValue
-    }
-    
-    typealias PersistentRepresentation = String
-    
-    static var sqliteTypeName: Vein.SQLiteTypeName { String.sqliteTypeName }
-    
-    var sqliteValue: Vein.SQLiteValue {
-        .text(rawValue)
-    }
-    
-    static func decode(sqliteValue: Vein.SQLiteValue) throws(Vein.MOCError) -> Group {
-        guard
-            case .text(let value) = sqliteValue,
-            let correspondingValue = Group(rawValue: value)
-        else { throw .propertyDecode(message: "raised by enum Group decoder")}
-        return correspondingValue
-    }
-    
-    init?(fromPersistent representation: String) {
-        self.init(rawValue: representation)
-    }
-    
+nonisolated enum Group: String, RawRepresentablePersistable, CaseIterable {    
     case football
     case soccer
     case baseball

--- a/Sources/Vein/Model/Protocols/Persistable.swift
+++ b/Sources/Vein/Model/Protocols/Persistable.swift
@@ -510,3 +510,56 @@ extension Array: Persistable where Element == ULID {
         return SQLiteJSONB(jsonString: serialized)
     }
 }
+
+/// Conform to this protocol as an easy way to make your RawRepresentable type ``Persistable``.
+///
+/// It will be stored as the RawValue's `PersistentRepresentation` in SQLite.
+/// Please note that changing the RawRepresentable implementation within one version might break decoding.
+/// It is recommended to only change it during Schema Version bumps.
+public protocol RawRepresentablePersistable: RawRepresentable, Persistable where
+    RawValue: Persistable,
+    PersistentRepresentation == RawValue.PersistentRepresentation
+{}
+extension RawRepresentablePersistable {
+    public init?(fromPersistent representation: RawValue.PersistentRepresentation) {
+        guard let rawValue = RawValue.init(fromPersistent: representation) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+    
+    public var asPersistentRepresentation: RawValue.PersistentRepresentation {
+        self.rawValue.asPersistentRepresentation
+    }
+}
+
+/// Conform to this protocol as an easy way to make your custom codable struct ``Persistable``.
+///
+/// It will be stored as JSONB in SQLite, allowing for performant custom filtering.
+/// Please note that changing the Codable implementation within one version might break decoding.
+/// It is recommended to only change it during Schema Version bumps.
+public protocol CodablePersistable: Codable, Persistable where PersistentRepresentation == SQLiteJSONB {}
+extension CodablePersistable {
+    public init?(fromPersistent representation: SQLiteJSONB) {
+        guard
+            let data = representation.jsonString.data(using: .utf8),
+            let instance = try? JSONDecoder().decode(Self.self, from: data)
+        else {
+            return nil
+        }
+        
+        self = instance
+    }
+    
+    public var asPersistentRepresentation: SQLiteJSONB {
+        do {
+            let serialized = try JSONEncoder().encode(self)
+            guard let jsonString = String(data: serialized, encoding: .utf8) else {
+                fatalError("Failed to convert JSON data for \(Self.self) to string.")
+            }
+            return SQLiteJSONB(jsonString: jsonString)
+        } catch {
+            fatalError("Failed to JSON-encode data for \(Self.self). Error: \(error), Description: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -115,7 +115,25 @@ public actor ManagedObjectContext {
         self.connection = connection
     }
     
-    public static func getKeyForDatabase(at path: String, appID: String) -> String? {
+    /// Retrieve the key encrypting the database, if applicable.
+    ///
+    /// Do not keep the key in memory or on screen for extended periods of time in production apps.
+    /// It should only be displayed as long as absolutely needed.
+    public nonisolated func getDatabaseKey() -> String? {
+        guard
+            let path = modelContainer.path,
+            modelContainer.encryptionEnabled
+        else {
+            return nil
+        }
+        return Self.getKeyForDatabase(
+            at: path,
+            appID: modelContainer.appID,
+            createIfMissing: false
+        )
+    }
+    
+    public static func getKeyForDatabase(at path: String, appID: String, createIfMissing: Bool = true) -> String? {
         let url = URL(fileURLWithPath: path)
         let fileName = url.lastPathComponent
         
@@ -124,7 +142,7 @@ public actor ManagedObjectContext {
         
         if let key = keychain[fileName] {
             return key
-        } else {
+        } else if createIfMissing {
             let keyData = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
             let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
             
@@ -138,7 +156,7 @@ public actor ManagedObjectContext {
         
         if let key = keyring[fileName] {
             return key
-        } else {
+        } else if createIfMissing {
             let keyData = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
             let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
             
@@ -147,9 +165,8 @@ public actor ManagedObjectContext {
             }
             return hexKey
         }
-        #else
-        return nil
         #endif
+        return nil
     }
 }
 

--- a/Sources/Vein/ModelContext/ModelContainer.swift
+++ b/Sources/Vein/ModelContext/ModelContainer.swift
@@ -3,7 +3,7 @@ import SQLiteDB
 
 public final class ModelContainer: @unchecked Sendable {
     public let migration: SchemaMigrationPlan.Type
-    private let path: String?
+    public let path: String?
     
     // Only force unwrapped to count as initialized,
     // so ManagedObjectContex.init can recieve the function

--- a/Tests/VeinTests/Persistable/Codable.swift
+++ b/Tests/VeinTests/Persistable/Codable.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+@testable import Vein
+#if TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinCore
+#endif
+
+extension PersistableTests {
+    @Test
+    func testCodablePersistable() async throws {
+        let metadataDate = Date(timeIntervalSince1970: 1782830817.0)
+        let (connection, objectID) = try setupContainer(date: metadataDate)
+        
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.persistable"
+        )
+        
+        guard
+            let model = try container.context.fetchAll(V0_0_1.Account.self).first
+        else {
+            Issue.record("Unexpectedly found no model.")
+            return
+        }
+        
+        #expect(model.metadata.createdAt == metadataDate)
+        #expect(model.metadata.createdInCity == "Berlin")
+        // Confirm the fetched model is really fetched from the db,
+        // not just from an identity map.
+        #expect(ObjectIdentifier(model) != objectID)
+    }
+    
+    @Test
+    func testCodablePersistableUpdate() async throws {
+        let metadataDate = Date(timeIntervalSince1970: 1782830817.0)
+        let (connection, objectID) = try setupContainer(date: metadataDate)
+        // TODO: Silence unused _keepaliveContainer once we use Swift 6.4
+        let (newObjectID, _keepaliveContainer) = try runUpdate()
+        
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.persistable"
+        )
+        
+        guard
+            let model = try container.context.fetchAll(V0_0_1.Account.self).first
+        else {
+            Issue.record("Unexpectedly found no model.")
+            return
+        }
+        
+        #expect(model.metadata.createdAt == metadataDate)
+        #expect(model.metadata.createdInCity == "Cologne")
+        // Confirm the fetched model is really fetched from the db,
+        // not just from an identity map.
+        #expect(ObjectIdentifier(model) != objectID)
+        #expect(ObjectIdentifier(model) != newObjectID)
+        
+        func runUpdate() throws -> (ObjectIdentifier?, ModelContainer) {
+            let updateContainer = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                connection: connection,
+                appID: "de.amethystsoft.vein.tests.persistable"
+            )
+            
+            guard
+                let model = try updateContainer.context.fetchAll(V0_0_1.Account.self).first
+            else {
+                Issue.record("Unexpectedly found no model.")
+                return (nil, updateContainer)
+            }
+            
+            #expect(model.metadata.createdAt == metadataDate)
+            #expect(model.metadata.createdInCity == "Berlin")
+            // Confirm the fetched model is really fetched from the db,
+            // not just from an identity map.
+            #expect(ObjectIdentifier(model) != objectID)
+            
+            model.metadata = .init(
+                createdAt: metadataDate,
+                createdInCity: "Cologne"
+            )
+            
+            #expect(updateContainer.context.hasChanges)
+            
+            try updateContainer.context.save()
+            
+            return (ObjectIdentifier(model), updateContainer)
+        }
+    }
+    
+    func setupContainer(date: Date) throws -> (Connection, ObjectIdentifier) {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.persistable"
+        )
+        
+        let metadata = V0_0_1.Account.Metadata(createdAt: date, createdInCity: "Berlin")
+        let model = V0_0_1.Account(metadata: metadata)
+        try container.context.insert(model)
+        try container.context.save()
+        
+        return (
+            container.getConnection(),
+            ObjectIdentifier(model)
+        )
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Account.self]
+    
+    @Model
+    final class Account: Identifiable {
+        var metadata: Metadata
+        
+        init(metadata: Metadata) {
+            self.metadata = metadata
+        }
+        
+        struct Metadata: CodablePersistable {
+            let createdAt: Date
+            let createdInCity: String
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/Tests/VeinTests/Persistable/RawRepresentable.swift
+++ b/Tests/VeinTests/Persistable/RawRepresentable.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import Vein
+#if TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinCore
+#endif
+
+@Suite
+struct PersistableTests {
+    @Test
+    func testRawRepresentablePersistable() async throws {
+        let (connection, objectID) = try setupContainer()
+        
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.persistable"
+        )
+        
+        guard
+            let model = try container.context.fetchAll(V0_0_1.Account.self).first
+        else {
+            Issue.record("Unexpectedly found no model.")
+            return
+        }
+        
+        #expect(model.accountType == .admin)
+        // Confirm the fetched model is really fetched from the db,
+        // not just from an identity map.
+        #expect(ObjectIdentifier(model) != objectID)
+    }
+    
+    @Test
+    func testRawRepresentablePersistableUpdate() async throws {
+        let (connection, objectID) = try setupContainer()
+        let newObjectID = try runUpdate()
+        
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            connection: connection,
+            appID: "de.amethystsoft.vein.tests.persistable"
+        )
+        
+        guard
+            let model = try container.context.fetchAll(V0_0_1.Account.self).first
+        else {
+            Issue.record("Unexpectedly found no model.")
+            return
+        }
+        
+        #expect(model.accountType == .user)
+        // Confirm the fetched model is really fetched from the db,
+        // not just from an identity map.
+        #expect(ObjectIdentifier(model) != objectID)
+        #expect(ObjectIdentifier(model) != newObjectID)
+        
+        func runUpdate() throws -> ObjectIdentifier? {
+            let updateContainer = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                connection: connection,
+                appID: "de.amethystsoft.vein.tests.persistable"
+            )
+            
+            guard
+                let model = try updateContainer.context.fetchAll(V0_0_1.Account.self).first
+            else {
+                Issue.record("Unexpectedly found no model.")
+                return nil
+            }
+            
+            #expect(model.accountType == .admin)
+            // Confirm the fetched model is really fetched from the db,
+            // not just from an identity map.
+            #expect(ObjectIdentifier(model) != objectID)
+            
+            model.accountType = .user
+            
+            #expect(updateContainer.context.hasChanges)
+            
+            try updateContainer.context.save()
+            
+            return ObjectIdentifier(model)
+        }
+    }
+    
+    private func setupContainer() throws -> (Connection, ObjectIdentifier) {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.tests.persistable"
+        )
+        
+        let model = V0_0_1.Account(accountType: .admin)
+        try container.context.insert(model)
+        try container.context.save()
+        
+        return (
+            container.getConnection(),
+            ObjectIdentifier(model)
+        )
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Account.self]
+    
+    @Model
+    final class Account: Identifiable {
+        var accountType: AccountType
+        
+        init(accountType: AccountType) {
+            self.accountType = accountType
+        }
+        
+        enum AccountType: String, RawRepresentablePersistable {
+            case user
+            case admin
+            case moderator
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/amethystsoft/vein/issues/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Added automatic persistence support for `RawRepresentable` types whose `RawValue` is itself persistable, plus a new `CodablePersistable` path that stores values as JSONB.
- Exposed the database path/key plumbing needed for key inspection without forcing key creation.
- Updated the basic example to use the new `RawRepresentablePersistable` conformance and to surface save errors more explicitly.
- Added tests covering both the new raw-representable and codable persistence flows, including update/migration behavior.

### Notable highlight
- Nice improvement: the new protocols remove a lot of boilerplate for common model types, making persistence both simpler and more ergonomic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->