### PR TITLE
Made some things internal or changed the name to _ to not show up in docs and communicate its not intended for public use

### DIFF
--- a/Sources/Vein/Model/PropertyWrappers/Fields.swift
+++ b/Sources/Vein/Model/PropertyWrappers/Fields.swift
@@ -12,9 +12,9 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
     private var readFromStore = false
     
     /// ONLY LET MACRO SET
-    public var key: String?
+    public var _key: String?
     /// ONLY LET MACRO SET
-    public weak var model: (any PersistentModel)?
+    public weak var _model: (any PersistentModel)?
     
     @_spi(VeinTesting) public let suppressUIUpdates: Bool
     
@@ -82,13 +82,12 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
     }
     
     public init(wrappedValue: T? = nil, suppressUIUpdates: Bool = false) {
-        self.key = nil
         self.store = wrappedValue
         self.suppressUIUpdates = suppressUIUpdates
     }
     
     private func setAndNotify(_ newValue: WrappedType) {
-        withObservationNotification {
+        _withObservationNotification {
             if !suppressUIUpdates {
                 model?.notifyOfChanges()
             }
@@ -100,7 +99,7 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
         }
     }
     
-    public func setStoreToCapturedState(_ state: Any) {
+    public func _setStoreToCapturedState(_ state: Any) {
         lock.withLock {
             guard let value = state as? WrappedType else {
                 fatalError(ManagedObjectContextError.capturedStateApplicationFailed(WrappedType.self, instanceKey).localizedDescription)
@@ -111,7 +110,7 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
         }
     }
     
-    public var persistableValue: T? {
+    public var _persistableValue: T? {
         get { wrappedValue }
         set { wrappedValue = newValue }
     }
@@ -123,7 +122,7 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
         storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, LazyField<T>>
     ) -> T? {
         get {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -132,7 +131,7 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
             return storage.wrappedValue
         }
         set {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -147,8 +146,8 @@ public final class LazyField<T: Persistable>: PersistedField, @unchecked Sendabl
 public final class Field<T: Persistable>: PersistedField, @unchecked Sendable {
     public typealias WrappedType = T
     
-    public var key: String?
-    public weak var model: (any PersistentModel)?
+    public var _key: String?
+    public weak var _model: (any PersistentModel)?
     private let lock = NSLock()
     
     package var store: T
@@ -192,20 +191,19 @@ public final class Field<T: Persistable>: PersistedField, @unchecked Sendable {
     
     public init(wrappedValue: T) {
         self.store = wrappedValue
-        self.key = nil
     }
     
     // Notifies before or after the locked store mutation depending on `callBeforeChange`;
     // notification always runs outside the lock to avoid callback deadlocks.
     private func setAndNotify(_ newValue: WrappedType) {
-        withObservationNotification({ model?.notifyOfChanges() }) {
+        _withObservationNotification({ model?.notifyOfChanges() }) {
             lock.withLock {
                 store = newValue
             }
         }
     }
     
-    public func setStoreToCapturedState(_ state: Any) {
+    public func _setStoreToCapturedState(_ state: Any) {
         lock.withLock {
             guard let value = state as? WrappedType else {
                 fatalError(ManagedObjectContextError.capturedStateApplicationFailed(WrappedType.self, instanceKey).localizedDescription)
@@ -215,7 +213,7 @@ public final class Field<T: Persistable>: PersistedField, @unchecked Sendable {
         }
     }
     
-    public var persistableValue: T {
+    public var _persistableValue: T {
         get { wrappedValue }
         set { wrappedValue = newValue }
     }
@@ -227,7 +225,7 @@ public final class Field<T: Persistable>: PersistedField, @unchecked Sendable {
         storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, Field<T>>
     ) -> T {
         get {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -236,7 +234,7 @@ public final class Field<T: Persistable>: PersistedField, @unchecked Sendable {
             return storage.wrappedValue
         }
         set {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed

--- a/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/ManyRelationship.swift
@@ -11,13 +11,13 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     public var isLazy: Bool { false }
     private let lock = NSLock()
     @_spi(VeinTesting) public var idStore = [ULID]()
-    private let _inverseKey = Mutex<String?>(nil)
-    public var inverseKey: String? {
+    private let inverseKeyStore = Mutex<String?>(nil)
+    public var _inverseKey: String? {
         get {
-            _inverseKey.value
+            inverseKeyStore.value
         }
         set {
-            _inverseKey.value = newValue
+            inverseKeyStore.value = newValue
         }
     }
     public let deleteRule: DeleteRule
@@ -25,11 +25,11 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     /// ONLY LET MACRO SET
     /// it is not protected from other threads,
     /// because proper use cannot change it to something wrong
-    public var key: String?
+    public var _key: String?
     /// ONLY LET MACRO SET
     /// it is not protected from other threads,
     /// because proper use cannot change it to something wrong
-    public weak var model: (any PersistentModel)?
+    public weak var _model: (any PersistentModel)?
     
     private var _wasTouched: Bool = false
     public var wasTouched: Bool {
@@ -72,7 +72,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         inverse: String? = nil,
         deleteRule: DeleteRule = .nullify
     ) {
-        self._inverseKey.value = inverse
+        self.inverseKeyStore.value = inverse
         self.deleteRule = deleteRule
     }
     
@@ -80,12 +80,12 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         guard let model, let context = model.context else { return [] }
         guard !ids.isEmpty else { return [] }
         
-        if inverseKey.isNil {
-            inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+        if _inverseKey.isNil {
+            _inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
         }
         
         do {
-            let result = try context.getModels(ids: ids, type: T.self, requestingModel: model, fieldKey: instanceKey, inverseKey: inverseKey)
+            let result = try context.getModels(ids: ids, type: T.self, requestingModel: model, fieldKey: instanceKey, inverseKey: _inverseKey)
             return result
         } catch {
             if case .noSuchTable = error {
@@ -106,7 +106,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         var oldIDs = [ULID]()
         let newIDs = newValue.map(\.id)
         
-        withObservationNotification {
+        _withObservationNotification {
             if !VeinNotificationGuard.isProcessing {
                 VeinNotificationGuard.$isProcessing.withValue(true) {
                     model?.notifyOfChanges()
@@ -132,30 +132,30 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     private func updateOtherSide(removed: [T], added: [T]) {
         guard let model, let context = model.context else { return }
         
-        if inverseKey.isNil {
-            inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+        if _inverseKey.isNil {
+            _inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
         }
         
         for target in removed {
             target._observers.value.removeObserver(id: model.id, key: instanceKey)
 
-            guard let inverseKey else {
+            guard let _inverseKey else {
                 continue
             }
-            model._observers.value.removeObserver(id: target.id, key: inverseKey)
+            model._observers.value.removeObserver(id: target.id, key: _inverseKey)
             
             target._setupFields()
             let predicateMatches = context._prepareForChange(of: target)
             
-            let matchingField = target._fields.first { $0.key == inverseKey }
+            let matchingField = target._fields.first { $0.key == _inverseKey }
             
-            withObservationNotification({ matchingField?.model?.notifyOfChanges() }) {
+            _withObservationNotification({ matchingField?.model?.notifyOfChanges() }) {
                 if var manyField = matchingField as? (any ManyRelationship) {
-                    manyField.persistableValue.removeAll { $0 == model.id }
+                    manyField._persistableValue.removeAll { $0 == model.id }
                     manyField.wasTouched = true
                 } else if var oneField = matchingField as? (any OneRelationship) {
-                    if oneField.persistableValue == model.id {
-                        oneField.persistableValue = nil
+                    if oneField._persistableValue == model.id {
+                        oneField._persistableValue = nil
                     }
                     oneField.wasTouched = true
                 }
@@ -167,16 +167,16 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         for target in added {
             setObservers(on: target, id: target.id)
             
-            guard let inverseKey else {
+            guard let _inverseKey else {
                 continue
             }
             
             target._setupFields()
             let predicateMatches = context._prepareForChange(of: target)
             
-            let matchingField = target._fields.first { $0.key == inverseKey }
+            let matchingField = target._fields.first { $0.key == _inverseKey }
             
-            withObservationNotification {
+            _withObservationNotification {
                 if !VeinNotificationGuard.isProcessing {
                     VeinNotificationGuard.$isProcessing.withValue(true) {
                         target.notifyOfChanges()
@@ -197,12 +197,12 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
                 }
                 
                 if var manyField = matchingField as? (any ManyRelationship) {
-                    if !manyField.persistableValue.contains(model.id) {
-                        manyField.persistableValue.append(model.id)
+                    if !manyField._persistableValue.contains(model.id) {
+                        manyField._persistableValue.append(model.id)
                     }
                     manyField.wasTouched = true
                 } else if var oneField = matchingField as? (any OneRelationship) {
-                    oneField.persistableValue = model.id
+                    oneField._persistableValue = model.id
                     oneField.wasTouched = true
                 }
                 
@@ -214,8 +214,8 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
     private func setObservers(on target: T?, id: ULID) {
         guard let model else { return }
         lock.withLock {
-            if inverseKey == nil {
-                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            if _inverseKey == nil {
+                _inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
             }
         }
         
@@ -226,8 +226,8 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
             }
         })
         
-        if let inverseKey {
-            model._observers.value.addObserver(id: id, key: inverseKey, observer: { [weak target] in
+        if let _inverseKey {
+            model._observers.value.addObserver(id: id, key: _inverseKey, observer: { [weak target] in
                 guard !VeinNotificationGuard.isProcessing else { return }
                 VeinNotificationGuard.$isProcessing.withValue(true) {
                     target?.notifyOfChanges()
@@ -236,7 +236,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         }
     }
     
-    public func setStoreToCapturedState(_ state: Any) {
+    public func _setStoreToCapturedState(_ state: Any) {
         lock.withLock {
             guard let value = state as? [ULID] else {
                 fatalError(
@@ -253,7 +253,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         }
     }
     
-    public var persistableValue: PersistableRepresentation {
+    public var _persistableValue: PersistableRepresentation {
         get {
             lock.withLock {
                 idStore
@@ -273,22 +273,22 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         guard
             let model,
             let context = model.context,
-            let inverseKey
+            let _inverseKey
         else { return }
         
         for target in wrappedValue {
-            withObservationNotification({ target.notifyOfChanges() }) {
+            _withObservationNotification({ target.notifyOfChanges() }) {
                 switch deleteRule {
                     case .nullify:
                         let predicateMatches = context._prepareForChange(of: target)
                         
-                        let inverse = target._fields.first { $0.key == inverseKey }
+                        let inverse = target._fields.first { $0.key == _inverseKey }
                         
                         if var manyField = inverse as? (any ManyRelationship) {
-                            manyField.persistableValue.removeAll(where: { $0 == model.id })
+                            manyField._persistableValue.removeAll(where: { $0 == model.id })
                             manyField.wasTouched = true
                         } else if var oneField = inverse as? (any OneRelationship) {
-                            oneField.persistableValue = nil
+                            oneField._persistableValue = nil
                             oneField.wasTouched = true
                         }
                         
@@ -314,7 +314,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
         storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, _ManyRelationship<T>>
     ) -> [T] {
         get {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -323,7 +323,7 @@ public final class _ManyRelationship<T: PersistentModel>: ManyRelationship, @unc
             return storage.wrappedValue
         }
         set {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed

--- a/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
@@ -11,13 +11,13 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
     
     private let lock = NSLock()
     private var idStore: ULID?
-    private let _inverseKey = Mutex<String?>(nil)
-    public var inverseKey: String? {
+    private let inverseKeyStore = Mutex<String?>(nil)
+    public var _inverseKey: String? {
         get {
-            _inverseKey.value
+            inverseKeyStore.value
         }
         set {
-            _inverseKey.value = newValue
+            inverseKeyStore.value = newValue
         }
     }
     public let deleteRule: DeleteRule
@@ -25,11 +25,11 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
     /// ONLY LET MACRO SET
     /// It is not protected from other threads,
     /// because proper use cannot change it to something wrong
-    public var key: String?
+    public var _key: String?
     /// ONLY LET MACRO SET
     /// It is not protected from other threads,
     /// because proper use cannot change it to something wrong
-    public weak var model: (any PersistentModel)?
+    public weak var _model: (any PersistentModel)?
     
     private var _wasTouched: Bool = false
     public var wasTouched: Bool {
@@ -91,7 +91,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         inverse: String? = nil,
         deleteRule: DeleteRule = .nullify
     ) {
-        self._inverseKey.value = inverse
+        self.inverseKeyStore.value = inverse
         self.deleteRule = deleteRule
     }
     
@@ -124,7 +124,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         var previousID: ULID?
         
         VeinNotificationGuard.$isProcessing.withValue(true) {
-            withObservationNotification( { model?.notifyOfChanges() }) {
+            _withObservationNotification( { model?.notifyOfChanges() }) {
                 lock.withLock {
                     previousID = idStore
                     idStore = newID
@@ -151,17 +151,17 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         guard let model, let context = model.context else { return }
         
         lock.withLock {
-            if inverseKey == nil {
-                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            if _inverseKey == nil {
+                _inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
             }
         }
         
         guard let target = get(for: id) else { return }
         target._observers.value.removeObserver(id: model.id, key: instanceKey)
         
-        guard let inverseKey else { return }
+        guard let _inverseKey else { return }
         if isRemoving {
-            model._observers.value.removeObserver(id: target.id, key: inverseKey)
+            model._observers.value.removeObserver(id: target.id, key: _inverseKey)
         } else {
             setObservers(on: target, id: target.id)
         }
@@ -170,19 +170,19 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         
         let predicateMatches = context._prepareForChange(of: target)
         
-        let matchingField = target._fields.first { $0.key == inverseKey }
+        let matchingField = target._fields.first { $0.key == _inverseKey }
         
-        withObservationNotification({ target.notifyOfChanges()}) {
+        _withObservationNotification({ target.notifyOfChanges()}) {
             
             if var manyField = matchingField as? (any ManyRelationship) {
                 if isRemoving {
-                    manyField.persistableValue.removeAll { $0 == model.id }
-                } else if !manyField.persistableValue.contains(model.id) {
-                    manyField.persistableValue.append(model.id)
+                    manyField._persistableValue.removeAll { $0 == model.id }
+                } else if !manyField._persistableValue.contains(model.id) {
+                    manyField._persistableValue.append(model.id)
                 }
                 manyField.wasTouched = true
             } else if var oneField = matchingField as? (any OneRelationship) {
-                oneField.persistableValue = isRemoving ? nil : model.id
+                oneField._persistableValue = isRemoving ? nil : model.id
                 oneField.wasTouched = true
             }
             
@@ -193,8 +193,8 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
     private func setObservers(on target: T?, id: ULID) {
         guard let model else { return }
         lock.withLock {
-            if inverseKey == nil {
-                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            if _inverseKey == nil {
+                _inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
             }
         }
         
@@ -205,8 +205,8 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
             }
         })
         
-        if let inverseKey {
-            model._observers.value.addObserver(id: id, key: inverseKey, observer: { [weak target] in
+        if let _inverseKey {
+            model._observers.value.addObserver(id: id, key: _inverseKey, observer: { [weak target] in
                 guard !VeinNotificationGuard.isProcessing else { return }
                 VeinNotificationGuard.$isProcessing.withValue(true) {
                     target?.notifyOfChanges()
@@ -215,7 +215,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         }
     }
     
-    public func setStoreToCapturedState(_ state: Any) {
+    public func _setStoreToCapturedState(_ state: Any) {
         lock.withLock {
             guard let value = state as? ULID? else {
                 fatalError(
@@ -232,7 +232,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         }
     }
     
-    public var persistableValue: ULID? {
+    public var _persistableValue: ULID? {
         get {
             lock.withLock {
                 idStore
@@ -255,28 +255,28 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         else { return }
         
         lock.withLock {
-            if inverseKey == nil {
-                inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
+            if _inverseKey == nil {
+                _inverseKey = T._inverseFields[model.typeIdentifier]?[instanceKey]
             }
         }
         
         guard
-            let inverseKey,
+            let _inverseKey,
             let target = wrappedValue
         else { return }
         
-        withObservationNotification({ target.notifyOfChanges() }) {
+        _withObservationNotification({ target.notifyOfChanges() }) {
             switch deleteRule {
                 case .nullify:
                     let predicateMatches = context._prepareForChange(of: target)
                     
-                    let inverse = target._fields.first { $0.key == inverseKey }
+                    let inverse = target._fields.first { $0.key == _inverseKey }
                     
                     if var manyField = inverse as? (any ManyRelationship) {
-                        manyField.persistableValue.removeAll(where: { $0 == model.id })
+                        manyField._persistableValue.removeAll(where: { $0 == model.id })
                         manyField.wasTouched = true
                     } else if var oneField = inverse as? (any OneRelationship) {
-                        oneField.persistableValue = nil
+                        oneField._persistableValue = nil
                         oneField.wasTouched = true
                     }
                     
@@ -301,7 +301,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
         storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, _OneRelationship<T>>
     ) -> T? {
         get {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -310,7 +310,7 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
             return storage.wrappedValue
         }
         set {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed

--- a/Sources/Vein/Model/PropertyWrappers/PrimaryKeyWrapper.swift
+++ b/Sources/Vein/Model/PropertyWrappers/PrimaryKeyWrapper.swift
@@ -7,7 +7,12 @@ public class PrimaryKey: PersistedField, @unchecked Sendable {
     static let logger = Logger(label: "Vein PrimaryKey")
     public typealias WrappedType = ULID
     
-    public let key: String? = "id"
+    public var _key: String? {
+        get {
+            "id"
+        }
+        set {}
+    }
     
     private let lock = NSLock()
     
@@ -47,22 +52,16 @@ public class PrimaryKey: PersistedField, @unchecked Sendable {
         UUID.sqliteTypeName
     }
     
-    public weak var model: (any PersistentModel)?
-    
-    public var projectedValue: PersistanceChecker {
-        PersistanceChecker {
-            self.model?.context != nil
-        }
-    }
+    public weak var _model: (any PersistentModel)?
     
     public init(wrappedValue: ULID = ULID()) {
         self.store = wrappedValue
     }
     
     /// No-op: Primary key is immutable after insertion and doesn't participate in rollback.
-    public func setStoreToCapturedState(_ state: Any) {}
+    public func _setStoreToCapturedState(_ state: Any) {}
     
-    public var persistableValue: ULID {
+    public var _persistableValue: ULID {
         get { self.wrappedValue }
         set { self.wrappedValue = newValue }
     }
@@ -74,7 +73,7 @@ public class PrimaryKey: PersistedField, @unchecked Sendable {
         storage storageKeyPath: ReferenceWritableKeyPath<OuterSelf, PrimaryKey>
     ) -> ULID {
         get {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -83,7 +82,7 @@ public class PrimaryKey: PersistedField, @unchecked Sendable {
             return storage.wrappedValue
         }
         set {
-            let storage = observed[keyPath: storageKeyPath]
+            var storage = observed[keyPath: storageKeyPath]
             storage.lock.withLock {
                 if storage.model == nil {
                     storage.model = observed
@@ -91,16 +90,5 @@ public class PrimaryKey: PersistedField, @unchecked Sendable {
             }
             storage.wrappedValue = newValue
         }
-    }
-}
-
-
-public struct PersistanceChecker {
-    private let getPersistanceState: () -> Bool
-    package init(getPersistanceState: @escaping () -> Bool) {
-        self.getPersistanceState = getPersistanceState
-    }
-    public var isPersisted: Bool {
-        getPersistanceState()
     }
 }

--- a/Sources/Vein/Model/Protocols/FieldBase.swift
+++ b/Sources/Vein/Model/Protocols/FieldBase.swift
@@ -4,17 +4,45 @@ import SQLiteDB
 public protocol FieldBase {
     associatedtype WrappedType: Persistable
     static var sqliteTypeName: SQLiteTypeName { get }
-    var key: String? { get }
-    var model: (any PersistentModel)? { get }
-    func setStoreToCapturedState(_ state: Any)
+    var _key: String? { get set }
+    var _model: (any PersistentModel)? { get set }
+    func _setStoreToCapturedState(_ state: Any)
     var isLazy: Bool { get }
     var wasTouched: Bool { get }
     
-    var persistableValue: WrappedType { get set }
+    var _persistableValue: WrappedType { get set }
 }
 
 extension FieldBase {
-    public var instanceKey: String {
+    var key: String? {
+        get {
+            _key
+        }
+        
+        set {
+            _key = newValue
+        }
+    }
+    
+    weak var model: (any PersistentModel)? {
+        get {
+            _model
+        }
+        set {
+            _model = newValue
+        }
+    }
+    
+    var persistableValue: WrappedType {
+        get {
+            _persistableValue
+        }
+        set {
+            _persistableValue = newValue
+        }
+    }
+    
+    var instanceKey: String {
         guard let key else {
             fatalError(MOCError.keyMissing(message: "raised by Field property of Type '\(WrappedType.self)'").localizedDescription)
         }
@@ -26,24 +54,24 @@ extension FieldBase {
     }
     
     var instanceObjectID: ObjectIdentifier {
-        guard let model else {
+        guard let _model else {
             fatalError(MOCError.modelReference(message: "raised by Field property of Type '\(WrappedType.self)'").localizedDescription)
         }
-        return model.typeIdentifier
+        return _model.typeIdentifier
     }
     
     var instanceSchema: String {
-        guard let model else {
+        guard let _model else {
             fatalError(MOCError.modelReference(message: "raised by Field property of Type '\(WrappedType.self)'").localizedDescription)
         }
-        return model._getSchema()
+        return _model._getSchema()
     }
     
     var instanceID: ULID {
-        guard let model else {
+        guard let _model else {
             fatalError(MOCError.modelReference(message: "raised by Field property of Type '\(WrappedType.self)'").localizedDescription)
         }
-        return model.id
+        return _model.id
     }
     
     /// This expressible should only be used for fetching.
@@ -75,7 +103,7 @@ extension FieldBase {
         }
     }
     
-    public func decode(_ row: SQLiteDB.Row) -> WrappedType.PersistentRepresentation {
+    func decode(_ row: SQLiteDB.Row) -> WrappedType.PersistentRepresentation {
         do {
             let typeName = WrappedType.sqliteTypeName
             
@@ -136,7 +164,7 @@ extension FieldBase {
         }
     }
     
-    public func asDTO() -> PersistedFieldDTO {
+    func asDTO() -> PersistedFieldDTO {
         PersistedFieldDTO(
             key: instanceKey,
             id: instanceID,
@@ -146,7 +174,7 @@ extension FieldBase {
         )
     }
     
-    public func migrate(on builder: inout Vein.TableBuilder) {
+    func migrate(on builder: inout Vein.TableBuilder) {
         let required = !WrappedType.sqliteTypeName.isNull
         
         builder = switch SQLiteTypeName.notNull(WrappedType.sqliteTypeName) {

--- a/Sources/Vein/Model/Protocols/PersistedRelationship.swift
+++ b/Sources/Vein/Model/Protocols/PersistedRelationship.swift
@@ -8,10 +8,10 @@ public protocol PersistedRelationship: FieldBase {
 }
 
 public protocol ManyRelationship: PersistedRelationship {
-    var persistableValue: [ULID] { get set }
+    var _persistableValue: [ULID] { get set }
 }
 public protocol OneRelationship: PersistedRelationship {
-    var persistableValue: ULID? { get set }
+    var _persistableValue: ULID? { get set }
 }
 
 public enum DeleteRule {

--- a/Sources/Vein/Model/Protocols/PersistentModel.swift
+++ b/Sources/Vein/Model/Protocols/PersistentModel.swift
@@ -24,12 +24,9 @@ public protocol PersistentModel: AnyObject, Sendable {
     
     static var version: ModelVersion { get }
     
-    nonisolated var _observers: Mutex<ReferenceCountedObservers> { get }
+    nonisolated var _observers: Mutex<_ReferenceCountedObservers> { get }
     
     static var _inverseFields: [ObjectIdentifier: [String: String]] { get }
-    
-    func extractPrimitiveState() -> PrimitiveState
-    func applyPrimitiveState(_ state: PrimitiveState)
     
     static func _predicateInformation(for keyPath: PartialKeyPath<Self>) -> FieldInformation?
     
@@ -58,19 +55,19 @@ extension PersistentModel {
         }
     }
     
-    public func extractPrimitiveState() -> PrimitiveState {
+    func extractPrimitiveState() -> PrimitiveState {
         var data = [String: Any]()
         
         for field in _fields {
-            data[field.instanceKey] = field.persistableValue
+            data[field.instanceKey] = field._persistableValue
         }
         
         return PrimitiveState(values: data)
     }
     
-    public func applyPrimitiveState(_ state: PrimitiveState) {
+    func applyPrimitiveState(_ state: PrimitiveState) {
         for field in _fields {
-            field.setStoreToCapturedState(state.values[field.instanceKey]!)
+            field._setStoreToCapturedState(state.values[field.instanceKey]!)
         }
     }
     

--- a/Sources/Vein/Model/Values/ReferenceCountedObservers.swift
+++ b/Sources/Vein/Model/Values/ReferenceCountedObservers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ULID
 
-public struct ReferenceCountedObservers: @unchecked Sendable {
+public struct _ReferenceCountedObservers: @unchecked Sendable {
     @_spi(VeinTesting) public var references = [ULID: Set<String>]()
     @_spi(VeinTesting) public var observers = [ULID: () -> Void]()
     

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Fetch.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Fetch.swift
@@ -4,7 +4,7 @@ import Foundation
 
 extension ManagedObjectContext {
     /// Returns all models matching the predicate.
-    public nonisolated func _fetchAll<T: PersistentModel>(_ predicate: ModelPredicate<T>) throws(MOCError) -> [T] {
+    nonisolated func _fetchAll<T: PersistentModel>(_ predicate: ModelPredicate<T>) throws(MOCError) -> [T] {
         do {
             let table = Table(T.schema).filter(predicate.sql)
             let eagerLoadedFields = T._fieldInformation.eagerLoaded
@@ -99,7 +99,7 @@ extension ManagedObjectContext {
         }
     }
     
-    public nonisolated func _fetchSingleProperty<Field: PersistedField>(field: Field) throws(MOCError) -> Field.WrappedType.PersistentRepresentation {
+    nonisolated func _fetchSingleProperty<Field: PersistedField>(field: Field) throws(MOCError) -> Field.WrappedType.PersistentRepresentation {
         typealias T = Field.WrappedType
         guard let key = field.key else {
             if let model = field.model {
@@ -132,7 +132,7 @@ extension ManagedObjectContext {
         }
     }
     
-    public nonisolated func getAllStoredSchemas() throws -> [String] {
+    nonisolated func getAllStoredSchemas() throws -> [String] {
         let tables = try connection.schema.objectDefinitions(type: .table)
         return tables.map { $0.name }.filter {
             [
@@ -142,7 +142,7 @@ extension ManagedObjectContext {
         }
     }
     
-    public nonisolated func getNonEmptySchemas() throws -> [String] {
+    nonisolated func getNonEmptySchemas() throws -> [String] {
         let tables = try connection.schema.objectDefinitions(type: .table)
         let filtered = tables.map { $0.name }.filter {
             [

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
@@ -7,7 +7,7 @@ extension ManagedObjectContext {
             let table = Table(model._getSchema())
             let values = model._fields.map {
                 return $0
-                    .persistableValue
+                    ._persistableValue
                     .asPersistentRepresentation
                     .sqliteSetter(key: $0.instanceKey)
             }
@@ -48,7 +48,7 @@ extension ManagedObjectContext {
                     model._fields
                         .filter { $0.wasTouched }
                         .map {
-                            $0.persistableValue
+                            $0._persistableValue
                                 .asPersistentRepresentation
                                 .sqliteSetter(key: $0.instanceKey)
                         }

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Relationship.swift
@@ -3,7 +3,7 @@ import SQLiteDB
 import Foundation
 
 extension ManagedObjectContext {
-    public nonisolated func getModel<T: PersistentModel>(id: ULID, type: T.Type) throws(MOCError) -> T? {
+    nonisolated func getModel<T: PersistentModel>(id: ULID, type: T.Type) throws(MOCError) -> T? {
         if let model = identityMap.getTracked(type, id: id) {
             return model
         }
@@ -15,7 +15,7 @@ extension ManagedObjectContext {
         ).first
     }
     
-    public nonisolated func getModels<T: PersistentModel>(
+    nonisolated func getModels<T: PersistentModel>(
         ids: [ULID],
         type: T.Type,
         requestingModel: any PersistentModel,

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Surface.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Surface.swift
@@ -93,7 +93,7 @@ extension ManagedObjectContext {
         scheduleNotification(model)
     }
     
-    public nonisolated func _prepareForChange(of model: any PersistentModel) -> [Int] {
+    nonisolated func _prepareForChange(of model: any PersistentModel) -> [Int] {
         writeCache.mutate { _,_,_, states in
             if states[model.typeIdentifier, default: [:]][model.id] == nil {
                 states[
@@ -117,7 +117,7 @@ extension ManagedObjectContext {
     
     /// Registers the change on the context and updates Queries if necessary
     /// Only intended to be called by Fields
-    public nonisolated func _markTouched(
+    nonisolated func _markTouched(
         _ model: any PersistentModel,
         previouslyMatching predicateHashes: [Int]
     ) {

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Surface.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Surface.swift
@@ -464,7 +464,7 @@ package final class WriteCache: Sendable {
     
     private nonisolated let lock = NSLock()
     
-    package nonisolated func mutate<R>(
+    nonisolated func mutate<R>(
         _ block: (
             _ inserts: inout WriteCacheDictionary,
             _ touches: inout WriteCacheDictionary,

--- a/Sources/Vein/ModelContext/Utils/FieldExtension.swift
+++ b/Sources/Vein/ModelContext/Utils/FieldExtension.swift
@@ -1,5 +1,5 @@
 extension [PersistedField] {
-    public var eagerLoaded: [any PersistedField] {
+    var eagerLoaded: [any PersistedField] {
         self.compactMap {
             if $0.isLazy { return nil }
             return $0

--- a/Sources/Vein/ModelContext/Values/AccessMode.swift
+++ b/Sources/Vein/ModelContext/Values/AccessMode.swift
@@ -1,4 +1,0 @@
-public enum AccessMode {
-    case write
-    case readWrite
-}

--- a/Sources/Vein/ModelContext/Values/DTOs.swift
+++ b/Sources/Vein/ModelContext/Values/DTOs.swift
@@ -1,14 +1,14 @@
 import Foundation
 import SQLiteDB
 
-public struct PersistedFieldDTO: Sendable {
+struct PersistedFieldDTO: Sendable {
     let key: String
     let id: ULID
     let schema: String
     let sqliteType: SQLiteTypeName
     let enclosingObjectID: ObjectIdentifier
     
-    public init(key: String, id: ULID, schema: String, sqliteType: SQLiteTypeName, enclosingObjectID: ObjectIdentifier) {
+    init(key: String, id: ULID, schema: String, sqliteType: SQLiteTypeName, enclosingObjectID: ObjectIdentifier) {
         self.key = key
         self.id = id
         self.schema = schema

--- a/Sources/Vein/ModelContext/Values/PrimitiveState.swift
+++ b/Sources/Vein/ModelContext/Values/PrimitiveState.swift
@@ -1,3 +1,3 @@
-public struct PrimitiveState {
-    public let values: [String: Any]
+struct PrimitiveState {
+    let values: [String: Any]
 }

--- a/Sources/Vein/ModelContext/Values/TableBuilder.swift
+++ b/Sources/Vein/ModelContext/Values/TableBuilder.swift
@@ -1,6 +1,6 @@
 import SQLiteDB
 
-public struct TableBuilder {
+struct TableBuilder {
     private let context: ManagedObjectContext
     private let schemaName: String
     private var schema: (SQLiteDB.TableBuilder) -> Void
@@ -12,7 +12,7 @@ public struct TableBuilder {
     }
     
     @discardableResult
-    public func id() -> Self {
+    func id() -> Self {
         var copy = self
         copy.schema = { t in
             t.column(SQLExpression<String>("id"), primaryKey: true)
@@ -21,7 +21,7 @@ public struct TableBuilder {
     }
     
     @discardableResult
-    public func field(
+    func field(
         _ key: String,
         type: UnderlayingFieldType,
         unique: Bool = false
@@ -36,7 +36,7 @@ public struct TableBuilder {
         return copy
     }
     
-    public func run() throws(ManagedObjectContextError) {
+    func run() throws(ManagedObjectContextError) {
         try context.run(Table(schemaName).create (ifNotExists: true) { t in
             schema(t)
         })

--- a/Sources/Vein/ObservationNotificationConfigurable.swift
+++ b/Sources/Vein/ObservationNotificationConfigurable.swift
@@ -14,7 +14,7 @@ extension _ManyRelationship: ObservationNotificationConfigurable {}
 extension ManagedObjectContext: ObservationNotificationConfigurable {}
 
 extension ObservationNotificationConfigurable {
-    func withObservationNotification<R>(
+    func _withObservationNotification<R>(
         _ notification: () -> Void,
         block: () -> R
     ) -> R {

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -56,20 +56,20 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Mutex(Vein.ReferenceCountedObservers())
+                let _observers = Vein.Mutex(Vein._ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
-                    self.__clientID.model = self
-                    self.__clientID.key = "_clientID"
-                    self.__isDeleted.model = self
-                    self.__isDeleted.key = "_isDeleted"
-                    self.__updatedAt.model = self
-                    self.__updatedAt.key = "_updatedAt"
-                    self._test.model = self
-                    self._test.key = "test"
-                    self._id.model = self
+                    self.__clientID._model = self
+                    self.__clientID._key = "_clientID"
+                    self.__isDeleted._model = self
+                    self.__isDeleted._key = "_isDeleted"
+                    self.__updatedAt._model = self
+                    self.__updatedAt._key = "_updatedAt"
+                    self._test._model = self
+                    self._test._key = "test"
+                    self._id._model = self
                 }
             
                 let _context = Vein.Mutex<Vein.ManagedObjectContext?>(nil)
@@ -177,20 +177,20 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Mutex(Vein.ReferenceCountedObservers())
+                let _observers = Vein.Mutex(Vein._ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
-                    self.__clientID.model = self
-                    self.__clientID.key = "_clientID"
-                    self.__isDeleted.model = self
-                    self.__isDeleted.key = "_isDeleted"
-                    self.__updatedAt.model = self
-                    self.__updatedAt.key = "_updatedAt"
-                    self._test.model = self
-                    self._test.key = "test"
-                    self._id.model = self
+                    self.__clientID._model = self
+                    self.__clientID._key = "_clientID"
+                    self.__isDeleted._model = self
+                    self.__isDeleted._key = "_isDeleted"
+                    self.__updatedAt._model = self
+                    self.__updatedAt._key = "_updatedAt"
+                    self._test._model = self
+                    self._test._key = "test"
+                    self._id._model = self
                 }
             
                 let _context = Vein.Mutex<Vein.ManagedObjectContext?>(nil)
@@ -311,20 +311,20 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Mutex(Vein.ReferenceCountedObservers())
+                let _observers = Vein.Mutex(Vein._ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
-                    self.__clientID.model = self
-                    self.__clientID.key = "_clientID"
-                    self.__isDeleted.model = self
-                    self.__isDeleted.key = "_isDeleted"
-                    self.__updatedAt.model = self
-                    self.__updatedAt.key = "_updatedAt"
-                    self._test.model = self
-                    self._test.key = "test"
-                    self._id.model = self
+                    self.__clientID._model = self
+                    self.__clientID._key = "_clientID"
+                    self.__isDeleted._model = self
+                    self.__isDeleted._key = "_isDeleted"
+                    self.__updatedAt._model = self
+                    self.__updatedAt._key = "_updatedAt"
+                    self._test._model = self
+                    self._test._key = "test"
+                    self._id._model = self
                 }
             
                 let _context = Vein.Mutex<Vein.ManagedObjectContext?>(nil)
@@ -431,20 +431,20 @@ struct MacrosTests {
                     _setupFields()
                 }
             
-                let _observers = Vein.Mutex(Vein.ReferenceCountedObservers())
+                let _observers = Vein.Mutex(Vein._ReferenceCountedObservers())
             
                 /// Sets required properties for @Field values.
                 /// Gets generated automatically by @Model.
                 public func _setupFields() {
-                    self.__clientID.model = self
-                    self.__clientID.key = "_clientID"
-                    self.__isDeleted.model = self
-                    self.__isDeleted.key = "_isDeleted"
-                    self.__updatedAt.model = self
-                    self.__updatedAt.key = "_updatedAt"
-                    self._test.model = self
-                    self._test.key = "test"
-                    self._id.model = self
+                    self.__clientID._model = self
+                    self.__clientID._key = "_clientID"
+                    self.__isDeleted._model = self
+                    self.__isDeleted._key = "_isDeleted"
+                    self.__updatedAt._model = self
+                    self.__updatedAt._key = "_updatedAt"
+                    self._test._model = self
+                    self._test._key = "test"
+                    self._id._model = self
                 }
             
                 let _context = Vein.Mutex<Vein.ManagedObjectContext?>(nil)

--- a/Tests/VeinTests/ReferenceCountedObserversTest.swift
+++ b/Tests/VeinTests/ReferenceCountedObserversTest.swift
@@ -10,7 +10,7 @@ import Testing
 struct ReferenceCountedObserversTest {
     @Test("Observer is retained until all registered keys are removed")
     mutating func observerRetaining() {
-        var tracker = ReferenceCountedObservers()
+        var tracker = _ReferenceCountedObservers()
         let targetID = ULID()
         var notificationCount = 0
         let observer = { notificationCount += 1 }

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -49,8 +49,8 @@ public struct ModelMacroBase {
         for name in allFieldNames.sorted(by: { $0 < $1 }) {
             // This is not needed in every case, but its handy for internal ones
             // not using the wrappedValue.
-            fieldBodys.append("self._\(name).model = self")
-            fieldBodys.append("self._\(name).key = \"\(name)\"")
+            fieldBodys.append("self._\(name)._model = self")
+            fieldBodys.append("self._\(name)._key = \"\(name)\"")
             fieldAccessorBodies.append("self._\(name)")
         }
         
@@ -118,7 +118,7 @@ public struct ModelMacroBase {
         let eagerVarInit = eagerFields.initEagerRows()
         let relationshipInit = relationshipFields.initRelationshipRows()
         
-        fieldBodys.append("self._id.model = self")
+        fieldBodys.append("self._id._model = self")
         let fieldSetup = fieldBodys.joined(separator: "\n    ")
         let fieldAccessorSetup = fieldAccessorBodies.joined(separator: ",\n        ")
         
@@ -146,7 +146,7 @@ required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
     _setupFields()
 }
 
-let _observers = Vein.Mutex(Vein.ReferenceCountedObservers())
+let _observers = Vein.Mutex(Vein._ReferenceCountedObservers())
 
 /// Sets required properties for @Field values.
 /// Gets generated automatically by @Model.
@@ -356,7 +356,7 @@ extension Dictionary where Key == String, Value == String {
         self.map { key, value in
             let idType = value.isCollection ? "[ULID]": "ULID?"
             return """
-                self._\(key).persistableValue = try! \(idType).init(
+                self._\(key)._persistableValue = try! \(idType).init(
                         fromPersistent: \(idType).PersistentRepresentation.decode(
                             sqliteValue: fields[\"\(key)\"]!
                         )


### PR DESCRIPTION
resolves https://github.com/amethystsoft/vein/issues/65
It wasn’t as much as I expected. A lot is just required by public protocols

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Reduced the project’s public API surface to discourage unintended external use by moving multiple helpers, DTOs, and model/protocol storage hooks from `public`/`package` to internal defaults and/or underscore-based “engine” variants.

Key updates:
- Lowered visibility of several `ManagedObjectContext` helpers (fetch, relationship lookup, and surface/touch tracking) to non-public/internal in their respective files.
- Slimmed model/persistence interfaces by renaming and underscoring storage/protocol members:
  - Field/property wrapper backing properties and hooks like `key`/`model`/`persistableValue`/`setStoreToCapturedState` were renamed to `_key`/`_model`/`_persistableValue`/`_setStoreToCapturedState`.
  - Relationship wrappers (`OneRelationship`, `ManyRelationship`) and `FieldBase`/relationship protocols now use `_persistableValue` and underscore-backed requirements.
- Internalized additional model/persistence types and utilities:
  - Removed `AccessMode`.
  - Made `TableBuilder`, `PrimitiveState`, and `PersistedFieldDTO` non-public.
  - Renamed `ReferenceCountedObservers` → `_ReferenceCountedObservers` and updated model macro wiring accordingly.
  - Switched observation helper to `_withObservationNotification`.
- Updated the model macro expansion expectations and tests to match the new underscore-based wiring.

Nice cleanup: the underscore-SPI naming and macro-generated plumbing are now consistent across wrappers, protocols, persistence, and tests—so the public docs surface is smaller without changing the runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->