### PR TITLE
Changed Date representation to Double

### DIFF
--- a/Sources/Vein/Model/Protocols/Persistable.swift
+++ b/Sources/Vein/Model/Protocols/Persistable.swift
@@ -377,42 +377,21 @@ extension Data: Persistable, ColumnType {
     }
 }
 
-extension Date: Persistable, ColumnType {
-    public var sqliteTypeRepresentation: String { ISO8601Format(Date.sqliteFormatStyle) }
+extension Date: Persistable {
+    public var sqliteTypeRepresentation: Double { self.timeIntervalSince1970 }
     
-    public typealias SQLiteType = String
+    public typealias SQLiteType = Double
     
-    public typealias PersistentRepresentation = Self
+    public typealias PersistentRepresentation = Double
     
-    public var asPersistentRepresentation: Self { self }
+    public var asPersistentRepresentation: Double { self.timeIntervalSince1970 }
     
     public init?(fromPersistent representation: PersistentRepresentation) {
-        self = representation
-    }
-    
-    public static var sqliteFormatStyle: ISO8601FormatStyle {
-        .iso8601(timeZone: .gmt, includingFractionalSeconds: true, dateTimeSeparator: .space)
+        self = Date(timeIntervalSince1970: representation)
     }
     
     public static var sqliteTypeName: SQLiteTypeName {
-        .text
-    }
-    
-    public var sqliteValue: SQLiteValue {
-        .text(self.ISO8601Format(Date.sqliteFormatStyle))
-    }
-    
-    public static func decode(sqliteValue: SQLiteValue) throws(MOCError) -> Date {
-        switch sqliteValue {
-            case .text(let string):
-                do {
-                    return try sqliteFormatStyle.parse(string)
-                } catch {
-                    throw MOCError.propertyDecode(message: "recieved data couldn't be converted to 'Date'")
-                }
-            default:
-                throw MOCError.propertyDecode(message: "\(Self.self)")
-        }
+        .real
     }
 }
 

--- a/Tests/VeinTests/Migrations/Unchanged+Delete.swift
+++ b/Tests/VeinTests/Migrations/Unchanged+Delete.swift
@@ -317,9 +317,9 @@ fileprivate enum SimpleSchemaV0_0_2: VersionedSchema {
     @Model
     final class Test: Identifiable {
         @Field
-        var date: String
+        var date: Double
         
-        init(date: String) {
+        init(date: Double) {
             self.date = date
         }
     }
@@ -400,8 +400,7 @@ fileprivate enum SimpleMigrationSuccess: SchemaMigrationPlan {
             let models = try context.fetchAll(SimpleSchemaV0_0_2.Test.self)
             
             for model in models {
-                let date = try Date.sqliteFormatStyle.parse(model.date)
-                let newModel = SimpleSchemaV0_0_3.Test(date: Int(date.timeIntervalSince1970))
+                let newModel = SimpleSchemaV0_0_3.Test(date: Int(model.date))
                 try context.insert(newModel)
                 try context.delete(model)
             }


### PR DESCRIPTION
I decided to make that change because it’s more performant for filtering and more stable and DB Browsers usually allow you to change how a column should be rendered anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change switches `Date` persistence from an ISO-8601 text value to a `Double` Unix timestamp (`timeIntervalSince1970`), aligning storage with the new numeric representation for faster filtering and better database-tool compatibility.

It also updates the affected migration test schema so the `date` field uses `Double` end-to-end, simplifying the V2→V3 conversion.

Nice touch: the new representation removes string parsing/formatting from persistence, which should make the model both simpler and more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->