### PR TITLE
Added tutorial for custom persistable

### DIFF
--- a/Sources/Vein/Model/Protocols/Persistable.swift
+++ b/Sources/Vein/Model/Protocols/Persistable.swift
@@ -378,20 +378,12 @@ extension Data: Persistable, ColumnType {
 }
 
 extension Date: Persistable {
-    public var sqliteTypeRepresentation: Double { self.timeIntervalSince1970 }
-    
-    public typealias SQLiteType = Double
-    
     public typealias PersistentRepresentation = Double
     
     public var asPersistentRepresentation: Double { self.timeIntervalSince1970 }
     
     public init?(fromPersistent representation: PersistentRepresentation) {
         self = Date(timeIntervalSince1970: representation)
-    }
-    
-    public static var sqliteTypeName: SQLiteTypeName {
-        .real
     }
 }
 

--- a/Sources/Vein/Model/Protocols/Persistable.swift
+++ b/Sources/Vein/Model/Protocols/Persistable.swift
@@ -377,42 +377,21 @@ extension Data: Persistable, ColumnType {
     }
 }
 
-extension Date: Persistable, ColumnType {
-    public var sqliteTypeRepresentation: String { ISO8601Format(Date.sqliteFormatStyle) }
+extension Date: Persistable {
+    public var sqliteTypeRepresentation: Double { self.timeIntervalSince1970 }
     
-    public typealias SQLiteType = String
+    public typealias SQLiteType = Double
     
-    public typealias PersistentRepresentation = Self
+    public typealias PersistentRepresentation = Double
     
-    public var asPersistentRepresentation: Self { self }
+    public var asPersistentRepresentation: Double { self.timeIntervalSince1970 }
     
     public init?(fromPersistent representation: PersistentRepresentation) {
-        self = representation
-    }
-    
-    public static var sqliteFormatStyle: ISO8601FormatStyle {
-        .iso8601(timeZone: .gmt, includingFractionalSeconds: true, dateTimeSeparator: .space)
+        self = Date(timeIntervalSince1970: representation)
     }
     
     public static var sqliteTypeName: SQLiteTypeName {
-        .text
-    }
-    
-    public var sqliteValue: SQLiteValue {
-        .text(self.ISO8601Format(Date.sqliteFormatStyle))
-    }
-    
-    public static func decode(sqliteValue: SQLiteValue) throws(MOCError) -> Date {
-        switch sqliteValue {
-            case .text(let string):
-                do {
-                    return try sqliteFormatStyle.parse(string)
-                } catch {
-                    throw MOCError.propertyDecode(message: "recieved data couldn't be converted to 'Date'")
-                }
-            default:
-                throw MOCError.propertyDecode(message: "\(Self.self)")
-        }
+        .real
     }
 }
 

--- a/Sources/VeinCore/VeinCore.docc/Resources/custom-persistable-codable.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/custom-persistable-codable.swift
@@ -1,0 +1,7 @@
+import VeinCore
+
+struct AccountMetadata: CodablePersistable {
+    let createdAt: Date
+    let createdIn: String
+    // ...
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/custom-persistable-conformance.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/custom-persistable-conformance.swift
@@ -1,0 +1,11 @@
+import VeinCore
+
+extension Date: Persistable {
+    public typealias PersistentRepresentation = Double
+    
+    public var asPersistentRepresentation: Double { self.timeIntervalSince1970 }
+    
+    public init?(fromPersistent representation: PersistentRepresentation) {
+        self = Date(timeIntervalSince1970: representation)
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/custom-persistable-raw-representable.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/custom-persistable-raw-representable.swift
@@ -1,0 +1,8 @@
+import VeinCore
+
+enum AccountType: String, RawRepresentablePersistable {
+    case admin
+    case service
+    case sales
+    case user
+}

--- a/Sources/VeinCore/VeinCore.docc/Table of Contents.tutorial
+++ b/Sources/VeinCore/VeinCore.docc/Table of Contents.tutorial
@@ -20,4 +20,8 @@
     @Chapter(name: "Complex Migrations") {
         @TutorialReference(tutorial: "doc:ComplexMigrations")
     }
+    
+    @Chapter(name: "Custom Persistable") {
+        @TutorialReference(tutorial: "doc:CustomPersistable")
+    }
 }

--- a/Sources/VeinCore/VeinCore.docc/Tutorials/CustomPersistable.tutorial
+++ b/Sources/VeinCore/VeinCore.docc/Tutorials/CustomPersistable.tutorial
@@ -1,0 +1,52 @@
+@Tutorial(time: 5) {
+    @Intro(title: "Custom Persistable") {
+        Make your own types persistable. 
+        
+        > Important:
+        > Please note that `Persistable` implementations should not be changed within one schema version, as it will likely break decoding existing database entries. It's recommended to define any types you will persist namespaced inside the same `VersionedSchema` as the models consuming it.
+    }
+    
+    @Section(title: "RawRepresentable") {
+        @ContentAndMedia {
+            `RawRepresentable` types you can make `Persistable` by conforming them to `RawRepresentablePersistable`. For that to work `RawRepresentable.RawValue` needs to be `Persistable`. It will be stored in the DB the same way `RawRepresentable.RawValue` would be.
+        }
+        
+        @Steps {
+            @Step {
+                Define your `RawRepresentable` type, specify it's `RawValue` and add `RawRepresentablePersistable`.
+                
+                @Code(name: "Schemas.swift", file: custom-persistable-raw-representable)
+            }
+        }
+    }
+    
+    @Section(title: "Codable") {
+        @ContentAndMedia {
+            `Codable` types you can make `Persistable` by conforming them to `CodablePersistable`. You do not need to specify `Codable` separately as it is a protocol requirement. It will be stored as JSONB in the database.
+        }
+        
+        @Steps {
+            @Step {
+                Define your `CodablePersistable` type.
+                
+                @Code(name: "AccountMetadata.swift", file: custom-persistable-codable)
+            }
+        }
+    }
+        
+    @Section(title: "Manual Persistable") {
+        @ContentAndMedia {
+            Of course you can also just implement `Persistable` yourself. The following is an example from Vein's integrated conformances.
+            
+            `PersistentRepresentation` needs to be conform to `ColumnType`. `Int64`, `Double`, `Bool`, `String`, `Data`, `SQLiteJSONB` or `Optional where Wrapped: Persistable` for example already implement ColumnType and are ready to be used .
+        }
+        
+        @Steps {
+            @Step {
+                Extend your type with `Persistable`.
+                
+                @Code(name: "Persistable.swift", file: custom-persistable-conformance)
+            }
+        }
+    }
+}

--- a/Tests/VeinTests/Migrations/Unchanged+Delete.swift
+++ b/Tests/VeinTests/Migrations/Unchanged+Delete.swift
@@ -317,9 +317,9 @@ fileprivate enum SimpleSchemaV0_0_2: VersionedSchema {
     @Model
     final class Test: Identifiable {
         @Field
-        var date: String
+        var date: Double
         
-        init(date: String) {
+        init(date: Double) {
             self.date = date
         }
     }
@@ -400,8 +400,7 @@ fileprivate enum SimpleMigrationSuccess: SchemaMigrationPlan {
             let models = try context.fetchAll(SimpleSchemaV0_0_2.Test.self)
             
             for model in models {
-                let date = try Date.sqliteFormatStyle.parse(model.date)
-                let newModel = SimpleSchemaV0_0_3.Test(date: Int(date.timeIntervalSince1970))
+                let newModel = SimpleSchemaV0_0_3.Test(date: Int(model.date))
                 try context.insert(newModel)
                 try context.delete(model)
             }


### PR DESCRIPTION
(I’m accidentally still in the wrong branch, but shouldn’t matter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new DocC tutorial for “Custom Persistable” that walks through three ways to make types persistable: `RawRepresentable`, `Codable`, and manual `Persistable` conformance.

Also updated the docs with supporting example files:
- `AccountType` as a `RawRepresentablePersistable` enum
- `AccountMetadata` as a `CodablePersistable` model
- a manual `Date: Persistable` example using `Double`/`timeIntervalSince1970`

To support the manual example, `Date`’s core `Persistable` conformance was simplified to use only its persistent `Double` representation, removing the SQLite-specific column binding pieces from the model protocol implementation.

Nice touch: the tutorial is well-scaffolded with linked code snippets and a clear progression from easy to manual persistence approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->