### PR TITLE
Added swift check based fuzzy tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,6 +80,7 @@ let package = Package(
         .package(url: "https://github.com/amethystsoft/KeyringAccess", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.3.1")),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+        .package(url: "https://github.com/typelift/SwiftCheck", .upToNextMinor(from: "0.12.0")),
     ],
     targets: [
         .target(
@@ -139,7 +140,8 @@ let package = Package(
                 .product(name: "SQLiteDB", package: "swift-sqlcipher"),
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax")
+                .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax"),
+                .product(name: "SwiftCheck", package: "SwiftCheck", condition: .when(platforms: [.macOS, .linux]))
             ] + veinAPIToTestDependencies,
             swiftSettings: testSwiftSettings
         ),

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext+Persist.swift
@@ -86,7 +86,17 @@ extension ManagedObjectContext {
         }
         
         do {
-            try connection.run(query)
+            do {
+                try connection.run(query)
+            } catch let error as SQLiteDB.Result  {
+                let parsed = error.parse()
+                switch parsed {
+                    // If there is no table there's no delete to persist.
+                    // In memory changes are enough in this case.
+                    case .noSuchTable: break
+                    default: throw error
+                }
+            }
             model.context = nil
             
             Task { @MainActor in

--- a/Tests/VeinTests/SwiftCheck/SwiftCheck.swift
+++ b/Tests/VeinTests/SwiftCheck/SwiftCheck.swift
@@ -1,0 +1,150 @@
+#if canImport(SwiftCheck)
+import SwiftCheck
+import Foundation
+import XCTest
+@testable import Vein
+#if TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinCore
+#endif
+
+fileprivate typealias Test = V0_0_1.Test
+final class SwiftCheckSuite: XCTestCase {
+    func testIdempotentSave() {
+        property("Save is idempotent") <- forAll { (test: Test) in
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.SwiftCheck",
+                encryptionEnabled: false
+            )
+            
+            let context = container.context!
+            
+            try context.insert(test)
+            try! context.save()
+            let firstCount = try! context.fetchAll(Test.self).count
+            
+            do {
+                try context.insert(test) // Attempted re-insert or update
+                throw MOCError.other(message: "Didn't throw for inserting managed model.")
+            } catch let error as MOCError {
+                switch error {
+                    case .insertManagedModel: break
+                    default: throw error
+                }
+            }
+            try! context.save()
+            let secondCount = try! context.fetchAll(Test.self).count
+            
+            return firstCount == secondCount
+        }
+    }
+    
+    func testRoundTripPersistence() {
+        property("Round-trip persistence") <- forAll { (test: Test) in
+            let connection = try createTest(test: test)
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                connection: connection,
+                appID: "de.amethystsoft.vein.tests.SwiftCheck",
+                encryptionEnabled: false
+            )
+            
+            let fetchedTest = try! container.context.fetchAll(Test.self).first
+            
+            return fetchedTest?.id == test.id &&
+            fetchedTest?.someValue == test.someValue &&
+            fetchedTest?.text == test.text
+            
+            func createTest(test: Test) throws -> Connection {
+                let container = try ModelContainer(
+                    V0_0_1.self,
+                    migration: Migration.self,
+                    at: nil,
+                    appID: "de.amethystsoft.vein.tests.SwiftCheck",
+                    encryptionEnabled: false
+                )
+                
+                try container.context.insert(test)
+                try container.context.save()
+                
+                return container.getConnection()
+            }
+        }
+    }
+    
+    func testFilterReturnsCorrectSubset() {
+        property("Filter by someValue returns correct subset") <- forAll { (tests: [Test]) in
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.tests.SwiftCheck",
+                encryptionEnabled: false
+            )
+            
+            let context = container.context!
+            
+            try tests.forEach { try context.insert($0) }
+            try context.save()
+            
+            let targetLetter = "A"
+            let expectedCount = tests.filter { $0.someValue.contains(targetLetter) }.count
+            let predicate = #Predicate<Test> { test in
+                test.someValue.contains(targetLetter)
+            }
+            let fetchedCount = try context.fetchAll(predicate).count
+            
+            return fetchedCount == expectedCount
+        }
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self]
+    
+    @Model
+    final class Test: Identifiable {
+        var someValue: String
+        
+        @LazyField
+        var text: String?
+        
+        init(someValue: String, text: String?) {
+            self.someValue = someValue
+            self.text = text
+        }
+        
+        func getLazyField() -> LazyField<String> {
+            _text
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}
+
+extension V0_0_1.Test: Arbitrary {
+    static fileprivate var arbitrary: SwiftCheck.Gen<Test> {
+        return Gen<Test>.compose { dg in
+            Test(
+                someValue: dg.generate(),
+                text: dg.generate()
+            )
+        }
+    }
+}
+
+#endif

--- a/Tests/VeinTests/SwiftCheck/SwiftCheckOperations.swift
+++ b/Tests/VeinTests/SwiftCheck/SwiftCheckOperations.swift
@@ -1,0 +1,166 @@
+#if canImport(SwiftCheck)
+import SwiftCheck
+import Foundation
+import XCTest
+@testable import Vein
+#if TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+@_spi(VeinTesting) @testable import VeinCore
+#endif
+
+fileprivate typealias Test = V0_0_1.Test
+final class SwiftCheckOperationsSuite: XCTestCase {
+    func testRandomOperations() {
+        property("State matches local reference after random operations") <- forAll { (ops: [DatabaseOp]) in
+            let appID = "de.amethystsoft.vein.tests.RandomOps"
+            
+            var referenceArray = [TestSnapshot]()
+            
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: appID,
+                encryptionEnabled: false
+            )
+            
+            for op in ops {
+                switch op {
+                    case .insert(let test):
+                        referenceArray.append(TestSnapshot(id: test.id, someValue: test.someValue, text: test.text))
+                        try container.context.insert(test)
+                        
+                    case .delete(let index):
+                        guard !referenceArray.isEmpty else { break }
+                        let idx = abs(index) % referenceArray.count
+                        let toDeleteSnapshot = referenceArray.remove(at: idx)
+                        
+                        let id = toDeleteSnapshot.id
+                        let predicate = #Predicate<V0_0_1.Test> { $0.id == id }
+                        if let object = try container.context.fetchAll(predicate).first {
+                            try container.context.delete(object)
+                        }
+                        
+                    case .update(let index, let newVal):
+                        guard !referenceArray.isEmpty else { break }
+                        let idx = abs(index) % referenceArray.count
+                        
+                        let old = referenceArray[idx]
+                        referenceArray[idx] = TestSnapshot(id: old.id, someValue: newVal, text: old.text)
+                        
+                        
+                        let id = old.id
+                        let predicate = #Predicate<V0_0_1.Test> { $0.id == id }
+                        if let object = try container.context.fetchAll(predicate).first {
+                            object.someValue = newVal
+                        }
+                }
+            }
+            
+            try container.context.save()
+            
+            // Verification using a fresh context to ensure changes are read from db
+            let verificationContainer = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                connection: container.getConnection(),
+                appID: appID,
+                encryptionEnabled: false
+            )
+            
+            let fetchedModels = try verificationContainer.context.fetchAll(V0_0_1.Test.self)
+            
+            // Compare Snapshots to Fetched Models
+            let countsMatch = fetchedModels.count == referenceArray.count
+            
+            let sortedRef = referenceArray.sorted { $0.id < $1.id }
+            let sortedFetched = fetchedModels.sorted { $0.id < $1.id }
+            
+            let contentsMatch = zip(sortedRef, sortedFetched).allSatisfy { snapshot, fetched in
+                snapshot.someValue == fetched.someValue &&
+                snapshot.text == fetched.text
+            }
+            
+            return countsMatch && contentsMatch
+        }
+    }
+}
+
+struct TestSnapshot: Equatable {
+    let id: ULID
+    let someValue: String
+    let text: String?
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self]
+    
+    @Model
+    final class Test: Identifiable {
+        var someValue: String
+        
+        @LazyField
+        var text: String?
+        
+        init(someValue: String, text: String?) {
+            self.someValue = someValue
+            self.text = text
+        }
+        
+        func getLazyField() -> LazyField<String> {
+            _text
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}
+
+extension V0_0_1.Test: Arbitrary {
+    static fileprivate var arbitrary: SwiftCheck.Gen<Test> {
+        return Gen<Test>.compose { dg in
+            Test(
+                someValue: dg.generate(),
+                text: dg.generate()
+            )
+        }
+    }
+}
+
+fileprivate enum DatabaseOp: CustomStringConvertible {
+    case insert(V0_0_1.Test)
+    case delete(Int) // Delete at index
+    case update(Int, String) // Update index with new string
+    
+    var description: String {
+        switch self {
+            case .insert: return "Insert"
+            case .delete(let i): return "Delete at \(i)"
+            case .update(let i, _): return "Update at \(i)"
+        }
+    }
+}
+
+extension DatabaseOp: Arbitrary {
+    fileprivate static var arbitrary: Gen<DatabaseOp> {
+        return Gen<DatabaseOp>.one(of: [
+            V0_0_1.Test.arbitrary.map(DatabaseOp.insert),
+            Gen<Int>.choose((0, 100)).map(DatabaseOp.delete),
+            Gen<(Int, String)>.compose { dg in
+                (dg.generate(using: Gen.choose((0, 100))), dg.generate())
+            }.map(DatabaseOp.update)
+        ])
+    }
+}
+
+
+#endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added SwiftCheck-based property tests for persistence and operation sequences, and wired the package to include SwiftCheck in test builds on macOS/Linux.

Highlights:
- Added a missing-table guard in `ManagedObjectContext._writeDelete`, so delete operations now ignore `noSuchTable` errors instead of failing.
- Introduced property tests covering idempotent saves, round-trip persistence, filtering behavior, and randomized insert/delete/update sequences.
- Added SwiftCheck dependency/configuration to `Package.swift` and test targets.

Especially nice: the new property-based coverage exercises both schema behavior and operation ordering, which should help catch subtle persistence regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->