### PR TITLE
Added _isSynced field to make partial syncs possible in the future

### DIFF
--- a/Sources/Vein/Model/Protocols/Persistable.swift
+++ b/Sources/Vein/Model/Protocols/Persistable.swift
@@ -462,7 +462,7 @@ extension Optional: Persistable, ColumnType where Wrapped: Persistable {
             return .none
         } else if
             let representation = try? Wrapped.PersistentRepresentation
-                .decode(sqliteValue: sqliteValue),
+            .decode(sqliteValue: sqliteValue),
             let wrapped = Wrapped(fromPersistent: representation)
         {
             return wrapped

--- a/Sources/VeinCore/ModelMacro.swift
+++ b/Sources/VeinCore/ModelMacro.swift
@@ -33,7 +33,8 @@
     named(_predicateInformation),
     named(_updatedAt),
     named(_clientID),
-    named(_isDeleted)
+    named(_isDeleted),
+    named(_isSynced)
 )
 @attached(extension, conformances: PersistentModel, Sendable, names: named(version), named(schema))
 @attached(memberAttribute)

--- a/Sources/VeinSwiftUI/ModelMacro.swift
+++ b/Sources/VeinSwiftUI/ModelMacro.swift
@@ -35,7 +35,8 @@
         named(_predicateInformation),
         named(_updatedAt),
         named(_clientID),
-        named(_isDeleted)
+        named(_isDeleted),
+        named(_isSynced)
     )
     @attached(
         extension,

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -57,6 +57,9 @@ struct MacrosTests {
                         @Vein.LazyField(suppressUIUpdates: true)
                         var _isDeleted: Bool? = false
 
+                        @Vein.LazyField(suppressUIUpdates: true)
+                        var _isSynced: Bool? = false
+
                         required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                             self.id = id
                             self.test = try! String.init(
@@ -77,6 +80,8 @@ struct MacrosTests {
                             self.__clientID._key = "_clientID"
                             self.__isDeleted._model = self
                             self.__isDeleted._key = "_isDeleted"
+                            self.__isSynced._model = self
+                            self.__isSynced._key = "_isSynced"
                             self.__updatedAt._model = self
                             self.__updatedAt._key = "_updatedAt"
                             self._test._model = self
@@ -96,6 +101,7 @@ struct MacrosTests {
                                 self._id,
                                 self.__clientID,
                                 self.__isDeleted,
+                                self.__isSynced,
                                 self.__updatedAt,
                                 self._test
                             ]
@@ -117,6 +123,7 @@ struct MacrosTests {
                             switch keyPath {
                                 case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
                                 case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                                case \\._isSynced: Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false)
                                 case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                                 case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                                 case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
@@ -127,6 +134,7 @@ struct MacrosTests {
                         static let _fieldInformation: [Vein.FieldInformation] = [
                             Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
                             Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                            Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false),
                             Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                             Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         ]
@@ -178,6 +186,9 @@ struct MacrosTests {
                         @Vein.LazyField(suppressUIUpdates: true)
                         var _isDeleted: Bool? = false
 
+                        @Vein.LazyField(suppressUIUpdates: true)
+                        var _isSynced: Bool? = false
+
                         required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                             self.id = id
                             self.test = try! String.init(
@@ -198,6 +209,8 @@ struct MacrosTests {
                             self.__clientID._key = "_clientID"
                             self.__isDeleted._model = self
                             self.__isDeleted._key = "_isDeleted"
+                            self.__isSynced._model = self
+                            self.__isSynced._key = "_isSynced"
                             self.__updatedAt._model = self
                             self.__updatedAt._key = "_updatedAt"
                             self._test._model = self
@@ -217,6 +230,7 @@ struct MacrosTests {
                                 self._id,
                                 self.__clientID,
                                 self.__isDeleted,
+                                self.__isSynced,
                                 self.__updatedAt,
                                 self._test
                             ]
@@ -238,6 +252,7 @@ struct MacrosTests {
                             switch keyPath {
                                 case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
                                 case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                                case \\._isSynced: Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false)
                                 case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                                 case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                                 case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
@@ -248,6 +263,7 @@ struct MacrosTests {
                         static let _fieldInformation: [Vein.FieldInformation] = [
                             Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
                             Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                            Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false),
                             Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                             Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         ]
@@ -312,6 +328,9 @@ struct MacrosTests {
                         @Vein.LazyField(suppressUIUpdates: true)
                         var _isDeleted: Bool? = false
 
+                        @Vein.LazyField(suppressUIUpdates: true)
+                        var _isSynced: Bool? = false
+
                         required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                             self.id = id
                             self.test = try! String.init(
@@ -332,6 +351,8 @@ struct MacrosTests {
                             self.__clientID._key = "_clientID"
                             self.__isDeleted._model = self
                             self.__isDeleted._key = "_isDeleted"
+                            self.__isSynced._model = self
+                            self.__isSynced._key = "_isSynced"
                             self.__updatedAt._model = self
                             self.__updatedAt._key = "_updatedAt"
                             self._test._model = self
@@ -351,6 +372,7 @@ struct MacrosTests {
                                 self._id,
                                 self.__clientID,
                                 self.__isDeleted,
+                                self.__isSynced,
                                 self.__updatedAt,
                                 self._test
                             ]
@@ -372,6 +394,7 @@ struct MacrosTests {
                             switch keyPath {
                                 case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
                                 case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                                case \\._isSynced: Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false)
                                 case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                                 case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                                 case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
@@ -382,6 +405,7 @@ struct MacrosTests {
                         static let _fieldInformation: [Vein.FieldInformation] = [
                             Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
                             Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                            Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false),
                             Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                             Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         ]
@@ -432,6 +456,9 @@ struct MacrosTests {
                         @Vein.LazyField(suppressUIUpdates: true)
                         var _isDeleted: Bool? = false
 
+                        @Vein.LazyField(suppressUIUpdates: true)
+                        var _isSynced: Bool? = false
+
                         required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                             self.id = id
                             self.test = try! String.init(
@@ -452,6 +479,8 @@ struct MacrosTests {
                             self.__clientID._key = "_clientID"
                             self.__isDeleted._model = self
                             self.__isDeleted._key = "_isDeleted"
+                            self.__isSynced._model = self
+                            self.__isSynced._key = "_isSynced"
                             self.__updatedAt._model = self
                             self.__updatedAt._key = "_updatedAt"
                             self._test._model = self
@@ -471,6 +500,7 @@ struct MacrosTests {
                                 self._id,
                                 self.__clientID,
                                 self.__isDeleted,
+                                self.__isSynced,
                                 self.__updatedAt,
                                 self._test
                             ]
@@ -492,6 +522,7 @@ struct MacrosTests {
                             switch keyPath {
                                 case \\._clientID: Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false)
                                 case \\._isDeleted: Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false)
+                                case \\._isSynced: Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false)
                                 case \\._updatedAt: Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false)
                                 case \\.test: Vein.FieldInformation(String.sqliteTypeName, "test", true)
                                 case \\.id: Vein.FieldInformation(ULID.sqliteTypeName, "id", true)
@@ -502,6 +533,7 @@ struct MacrosTests {
                         static let _fieldInformation: [Vein.FieldInformation] = [
                             Vein.FieldInformation(String?.sqliteTypeName, "_clientID", false),
                             Vein.FieldInformation(Bool?.sqliteTypeName, "_isDeleted", false),
+                            Vein.FieldInformation(Bool?.sqliteTypeName, "_isSynced", false),
                             Vein.FieldInformation(Foundation.Date?.sqliteTypeName, "_updatedAt", false),
                             Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         ]

--- a/Tests/VeinTests/Persistable/Codable.swift
+++ b/Tests/VeinTests/Persistable/Codable.swift
@@ -49,7 +49,7 @@ extension PersistableTests {
         let metadataDate = Date(timeIntervalSince1970: 1782830817.0)
         let connection = try setupContainer(date: metadataDate)
         // TODO: Silence unused _keepaliveContainer once we use Swift 6.4
-        let (newObjectID, _keepaliveContainer) = try runUpdate()
+        let _keepaliveContainer = try runUpdate()
 
         let container = try ModelContainer(
             V0_0_1.self,
@@ -68,9 +68,8 @@ extension PersistableTests {
 
         #expect(model.metadata.createdAt == metadataDate)
         #expect(model.metadata.createdInCity == "Cologne")
-        #expect(ObjectIdentifier(model) != newObjectID)
 
-        func runUpdate() throws -> (ObjectIdentifier?, ModelContainer) {
+        func runUpdate() throws -> ModelContainer {
             let updateContainer = try ModelContainer(
                 V0_0_1.self,
                 migration: Migration.self,
@@ -83,7 +82,7 @@ extension PersistableTests {
                 let model = try updateContainer.context.fetchAll(V0_0_1.Account.self).first
             else {
                 Issue.record("Unexpectedly found no model.")
-                return (nil, updateContainer)
+                return updateContainer
             }
 
             #expect(model.metadata.createdAt == metadataDate)
@@ -98,7 +97,7 @@ extension PersistableTests {
 
             try updateContainer.context.save()
 
-            return (ObjectIdentifier(model), updateContainer)
+            return updateContainer
         }
     }
 

--- a/Tests/VeinTests/Persistable/Codable.swift
+++ b/Tests/VeinTests/Persistable/Codable.swift
@@ -23,7 +23,7 @@ extension PersistableTests {
     @Test
     func testCodablePersistable() async throws {
         let metadataDate = Date(timeIntervalSince1970: 1782830817.0)
-        let (connection, objectID) = try setupContainer(date: metadataDate)
+        let connection = try setupContainer(date: metadataDate)
 
         let container = try ModelContainer(
             V0_0_1.self,
@@ -42,15 +42,12 @@ extension PersistableTests {
 
         #expect(model.metadata.createdAt == metadataDate)
         #expect(model.metadata.createdInCity == "Berlin")
-        // Confirm the fetched model is really fetched from the db,
-        // not just from an identity map.
-        #expect(ObjectIdentifier(model) != objectID)
     }
 
     @Test
     func testCodablePersistableUpdate() async throws {
         let metadataDate = Date(timeIntervalSince1970: 1782830817.0)
-        let (connection, objectID) = try setupContainer(date: metadataDate)
+        let connection = try setupContainer(date: metadataDate)
         // TODO: Silence unused _keepaliveContainer once we use Swift 6.4
         let (newObjectID, _keepaliveContainer) = try runUpdate()
 
@@ -71,9 +68,6 @@ extension PersistableTests {
 
         #expect(model.metadata.createdAt == metadataDate)
         #expect(model.metadata.createdInCity == "Cologne")
-        // Confirm the fetched model is really fetched from the db,
-        // not just from an identity map.
-        #expect(ObjectIdentifier(model) != objectID)
         #expect(ObjectIdentifier(model) != newObjectID)
 
         func runUpdate() throws -> (ObjectIdentifier?, ModelContainer) {
@@ -94,9 +88,6 @@ extension PersistableTests {
 
             #expect(model.metadata.createdAt == metadataDate)
             #expect(model.metadata.createdInCity == "Berlin")
-            // Confirm the fetched model is really fetched from the db,
-            // not just from an identity map.
-            #expect(ObjectIdentifier(model) != objectID)
 
             model.metadata = .init(
                 createdAt: metadataDate,
@@ -111,8 +102,8 @@ extension PersistableTests {
         }
     }
 
-    func setupContainer(date: Date) throws -> (Connection, ObjectIdentifier) {
-        let container = try ModelContainer(
+    func setupContainer(date: Date) throws -> Connection {
+        let setupContainer = try ModelContainer(
             V0_0_1.self,
             migration: Migration.self,
             at: nil,
@@ -122,13 +113,10 @@ extension PersistableTests {
 
         let metadata = V0_0_1.Account.Metadata(createdAt: date, createdInCity: "Berlin")
         let model = V0_0_1.Account(metadata: metadata)
-        try container.context.insert(model)
-        try container.context.save()
+        try setupContainer.context.insert(model)
+        try setupContainer.context.save()
 
-        return (
-            container.getConnection(),
-            ObjectIdentifier(model)
-        )
+        return setupContainer.getConnection()
     }
 }
 

--- a/VeinMacrosCore/Sources/ModelMacroBase.swift
+++ b/VeinMacrosCore/Sources/ModelMacroBase.swift
@@ -46,6 +46,7 @@ public struct ModelMacroBase {
         lazyFields["_updatedAt"] = "Foundation.Date?"
         lazyFields["_clientID"] = "String?"
         lazyFields["_isDeleted"] = "Bool?"
+        lazyFields["_isSynced"] = "Bool?"
 
         let eagerFields = fieldVariables.fields()
 
@@ -152,6 +153,9 @@ public struct ModelMacroBase {
 
             @Vein.LazyField(suppressUIUpdates: true)
             var _isDeleted: Bool? = false
+
+            @Vein.LazyField(suppressUIUpdates: true)
+            var _isSynced: Bool? = false
 
             required init(id: Vein.ULID, fields: [String: Vein.SQLiteValue]) {
                 self.id = id


### PR DESCRIPTION
Just another preparation step. I don’t want to be limited to synced in full or not synced at all once I start implementing sync. So this field needs to exist, updatedAt alone wouldn’t be enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added `_isSynced` as a new synthesized model field to support future partial sync states, alongside the existing deleted-state tracking.

Updated macro generation and expectations so `_isSynced` is now:
- included in generated member lists
- synthesized as an optional `Bool` defaulting to `false`
- wired into field setup, field collections, and predicate/metadata handling
- covered by macro expansion tests

Nice touch: the macro tests were updated thoroughly across both SwiftUI and non-SwiftUI paths, which should make this change much safer to evolve later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->