### PR TITLE
Added Migration Testing Tutorial and improved validations of MigrationTester

### DIFF
--- a/Sources/Vein/Model/Protocols/Persistable.swift
+++ b/Sources/Vein/Model/Protocols/Persistable.swift
@@ -462,7 +462,7 @@ extension Optional: Persistable, ColumnType where Wrapped: Persistable {
             return .none
         } else if
             let representation = try? Wrapped.PersistentRepresentation
-                .decode(sqliteValue: sqliteValue),
+            .decode(sqliteValue: sqliteValue),
             let wrapped = Wrapped(fromPersistent: representation)
         {
             return wrapped

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-0.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-0.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct StepByStep {
+    @Test
+    func stepByStepVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-1.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-1.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct StepByStep {
+    @Test
+    func stepByStepVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+        
+        let username = "miakoring"
+        let bio = "Amethyst Vein"
+        let email = "example@amethystsoft.de"
+        
+        try tester.seed(
+            version: Version1.self,
+            with: { context in
+                let user = Version1.User(username: username)
+                let profile = Version1.Profile(bio: bio)
+                
+                try context.insert(user)
+                try context.insert(profile)
+                try context.save()
+            }
+        )
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-2.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-2.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct StepByStep {
+    @Test
+    func stepByStepVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+        
+        let username = "miakoring"
+        let bio = "Amethyst Vein"
+        let email = "example@amethystsoft.de"
+        
+        try tester.seed(
+            version: Version1.self,
+            with: { context in
+                let user = Version1.User(username: username)
+                let profile = Version1.Profile(bio: bio)
+                
+                try context.insert(user)
+                try context.insert(profile)
+                try context.save()
+            }
+        )
+        
+        try tester.migrateAndCheck(
+            version: Version2.self,
+            with: { context in
+                let users = try context
+                    .fetchAll(Version2.User.self)
+                #expect(users.count == 1)
+                
+                if let user = users.first {
+                    #expect(user.username == username)
+                    #expect(user.email == nil)
+                    
+                    user.email = email
+                }
+                
+                let profiles = try context
+                    .fetchAll(Version2.Profile.self)
+                #expect(profiles.count == 1)
+                
+                if let profile = profiles.first {
+                    #expect(profile.bio == bio)
+                }
+                
+                try context.save()
+            }
+        )
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-3.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-3.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct StepByStep {
+    @Test
+    func stepByStepVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+        
+        let username = "miakoring"
+        let bio = "Amethyst Vein"
+        let email = "example@amethystsoft.de"
+        
+        try tester.seed(
+            version: Version1.self,
+            with: { context in
+                let user = Version1.User(username: username)
+                let profile = Version1.Profile(bio: bio)
+                
+                try context.insert(user)
+                try context.insert(profile)
+                try context.save()
+            }
+        )
+        
+        try tester.migrateAndCheck(
+            version: Version2.self,
+            with: { context in
+                let users = try context
+                    .fetchAll(Version2.User.self)
+                #expect(users.count == 1)
+                
+                if let user = users.first {
+                    #expect(user.username == username)
+                    #expect(user.email == nil)
+                    
+                    user.email = email
+                }
+                
+                let profiles = try context
+                    .fetchAll(Version2.Profile.self)
+                #expect(profiles.count == 1)
+                
+                if let profile = profiles.first {
+                    #expect(profile.bio == bio)
+                }
+                
+                try context.save()
+            }
+        )
+        
+        try tester.migrateAndCheck(
+            version: Version3.self,
+            with: { context in
+                let users = try context
+                    .fetchAll(Version3.User.self)
+                #expect(users.count == 1)
+                
+                let profiles = try context
+                    .fetchAll(Version3.Profile.self)
+                #expect(profiles.count == 1)
+                
+                if let profile = profiles.first {
+                    #expect(profile.bio == bio)
+                    #expect(profile.internalID.hasPrefix("ID-"))
+                    if let id = Int(profile.internalID.dropFirst(3)) {
+                        #expect((1000...9999).contains(id))
+                    } else {
+                        Issue.record("Internal ID should be a number after `ID-` prefix")
+                    }
+                }
+            }
+        )
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-f-0.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-f-0.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct FullChain {
+    @Test
+    func fullChainVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-f-1.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-f-1.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct FullChain {
+    @Test
+    func fullChainVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+        
+        let username = "miakoring"
+        let bio = "Amethyst Vein"
+        let email = "example@amethystsoft.de"
+        
+        try tester.testCompleteChain(
+            initialData: { context in
+                let user = Version1.User(username: username)
+                let profile = Version1.Profile(bio: bio)
+                
+                try context.insert(user)
+                try context.insert(profile)
+                try context.save()
+            },
+            validations: [
+                
+            ]
+        )
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-f-2.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-f-2.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+import VeinCore
+import VeinTesting
+
+@MainActor
+struct FullChain {
+    @Test
+    func fullChainVerification() async throws {
+        let tester = try MigrationTester(migrationPlan: MigrationPlan.self)
+        
+        let username = "miakoring"
+        let bio = "Amethyst Vein"
+        let email = "example@amethystsoft.de"
+        
+        try tester.testCompleteChain(
+            initialData: { context in
+                let user = Version1.User(username: username)
+                let profile = Version1.Profile(bio: bio)
+                
+                try context.insert(user)
+                try context.insert(profile)
+                try context.save()
+            },
+            validations: [
+                Version3.version: { context in
+                    let users = try context
+                        .fetchAll(Version3.User.self)
+                    #expect(users.count == 1)
+                    
+                    let profiles = try context
+                        .fetchAll(Version3.Profile.self)
+                    #expect(profiles.count == 1)
+                    
+                    if let profile = profiles.first {
+                        #expect(profile.bio == bio)
+                        #expect(profile.internalID.hasPrefix("ID-"))
+                        if let id = Int(profile.internalID.dropFirst(3)) {
+                            #expect((1000...9999).contains(id))
+                        } else {
+                            Issue.record("Internal ID should be a number after `ID-` prefix")
+                        }
+                    }
+                }
+            ]
+        )
+    }
+}

--- a/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-schemas.swift
+++ b/Sources/VeinCore/VeinCore.docc/Resources/unit-test-migrations-schemas.swift
@@ -1,0 +1,127 @@
+import Foundation
+import VeinCore
+
+fileprivate enum Version1: VersionedSchema {
+    static let version = ModelVersion(1, 0, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self,
+        Profile.self
+    ]}
+    
+    @Model
+    final class User {
+        @Field var username: String
+        init(username: String) { self.username = username }
+    }
+    
+    @Model
+    final class Profile {
+        @Field var bio: String
+        init(bio: String) { self.bio = bio }
+    }
+}
+
+fileprivate enum Version2: VersionedSchema {
+    static let version = ModelVersion(1, 1, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self,
+        Profile.self
+    ]}
+    
+    @Model
+    final class User {
+        @Field var username: String
+        // Added field
+        @Field var email: String?
+        init(username: String, email: String?) {
+            self.username = username
+            self.email = email
+        }
+    }
+    
+    @Model
+    final class Profile {
+        @Field var bio: String
+        init(bio: String) { self.bio = bio }
+    }
+}
+
+fileprivate enum Version3: VersionedSchema {
+    static let version = ModelVersion(1, 2, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self,
+        Profile.self,
+        Post.self
+    ]}
+    
+    @Model
+    final class User {
+        @Field var username: String
+        @Field var email: String?
+        init(username: String, email: String?) {
+            self.username = username
+            self.email = email
+        }
+    }
+    
+    @Model
+    final class Profile {
+        @Field var bio: String
+        // added field
+        @Field var internalID: String
+        init(bio: String, internalID: String) {
+            self.bio = bio
+            self.internalID = internalID
+        }
+    }
+    
+    @Model
+    final class Post {
+        @Field var content: String
+        init(content: String) { self.content = content }
+    }
+}
+
+fileprivate enum MigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self,
+        Version2.self,
+        Version3.self
+    ]}
+    
+    static var stages: [Vein.MigrationStage] {[
+        v1ToV2,
+        v2ToV3,
+    ]}
+    
+    static let v1ToV2 = Vein.MigrationStage.complex(
+        fromVersion: Version1.self,
+        toVersion: Version2.self,
+        willMigrate: { context in
+            try Version1.User.fieldsAddedMigration(to: Version2.User.self, on: context)
+            try Version1.Profile.unchangedMigration(to: Version2.Profile.self, on: context)
+        },
+        didMigrate: nil
+    )
+    
+    static let v2ToV3 = Vein.MigrationStage.complex(
+        fromVersion: Version2.self,
+        toVersion: Version3.self,
+        willMigrate: { context in
+            // Basic migrations
+            try Version2.User.unchangedMigration(to: Version3.User.self, on: context)
+            
+            // Logic migration for Profile
+            let oldProfiles = try context.fetchAll(Version2.Profile.self)
+            for old in oldProfiles {
+                let new = Version3.Profile(
+                    bio: old.bio,
+                    internalID: "ID-\(Int.random(in: 1000...9999))"
+                )
+                try context.insert(new)
+                try context.delete(old)
+            }
+        },
+        didMigrate: nil
+    )
+}

--- a/Sources/VeinCore/VeinCore.docc/Table of Contents.tutorial
+++ b/Sources/VeinCore/VeinCore.docc/Table of Contents.tutorial
@@ -24,4 +24,8 @@
     @Chapter(name: "Custom Persistable") {
         @TutorialReference(tutorial: "doc:CustomPersistable")
     }
+    
+    @Chapter(name: "Unit Testing Migrations") {
+        @TutorialReference(tutorial: "doc:MigrationUnitTests")
+    }
 }

--- a/Sources/VeinCore/VeinCore.docc/Tutorials/MigrationUnitTests.tutorial
+++ b/Sources/VeinCore/VeinCore.docc/Tutorials/MigrationUnitTests.tutorial
@@ -1,7 +1,7 @@
 @Tutorial(time: 10) {
     @Intro(title: "Unit Testing Migrations") {
         Migrations are a crucial and complex operation. 
-        Please please please unit test your migrations, itÄs incredibly important for data integrity.
+        Please please please unit test your migrations, it's incredibly important for data integrity.
         
         To make unit tests slightly more pleasant, Vein comes with a testing helper.
     }

--- a/Sources/VeinCore/VeinCore.docc/Tutorials/MigrationUnitTests.tutorial
+++ b/Sources/VeinCore/VeinCore.docc/Tutorials/MigrationUnitTests.tutorial
@@ -1,0 +1,84 @@
+@Tutorial(time: 10) {
+    @Intro(title: "Unit Testing Migrations") {
+        Migrations are a crucial and complex operation. 
+        Please please please unit test your migrations, itÄs incredibly important for data integrity.
+        
+        To make unit tests slightly more pleasant, Vein comes with a testing helper.
+    }
+    
+    @Section(title: "The migration we are going to test:") {
+        @ContentAndMedia {
+            This is a shortened part of one of Vein's unit tests.
+        }
+        
+        @Steps {
+            @Step {
+                You would just use your own existing models and migrations.
+                
+                @Code(name: "Schemas.swift", file: unit-test-migrations-schemas)
+            }
+        }
+    }
+    
+    @Section(title: "Unit Testing") {
+        @ContentAndMedia {
+            There are two builtin ways to test your migrations.
+            First we're going to cover the step by step approach and then the full chain one.
+            You can choose whatever you like more.
+        }
+        
+        @Steps {
+            @Step {
+                First, create a `MigrationTester` from `VeinTesting`.
+                It will validate the protocol requirements of `VersionedSchema`.
+                
+                @Code(name: "StepByStepTest.swift", file: unit-test-migrations-0)
+            }
+            
+            @Step {
+                Now seed the database with arbitrary contents you want to migrate.
+                We recommend starting at the first version to cover everything.
+                
+                @Code(name: "StepByStepTest.swift", file: unit-test-migrations-1)
+            }
+            
+            @Step {
+                Now migrate to the next version and check the migration results.
+                
+                @Code(name: "StepByStepTest.swift", file: unit-test-migrations-2)
+            }
+            
+            @Step {
+                Repeat for any further versions until you're done.
+                
+                @Code(name: "StepByStepTest.swift", file: unit-test-migrations-3)
+            }
+        }
+    }
+        
+    @Section(title: "Unit Testing full migration chain") {
+        @ContentAndMedia {
+            The other option is migrating the whole chain and checking where you want to.
+        }
+        
+        @Steps {
+            @Step {
+                First, again create a `MigrationTester` from `VeinTesting`.
+                
+                @Code(name: "FullChainTest.swift", file: unit-test-migrations-f-0)
+            }
+            
+            @Step {
+                Just like before, seed the database with arbitrary contents you want to migrate.
+                
+                @Code(name: "FullChainTest.swift", file: unit-test-migrations-f-1)
+            }
+            
+            @Step {
+                For every version you want to check after migrating, add the version with a validation block to the validations dictionary.
+                
+                @Code(name: "FullChainTest.swift", file: unit-test-migrations-f-2)
+            }
+        }
+    }
+}

--- a/Sources/VeinTesting/MigrationTester.swift
+++ b/Sources/VeinTesting/MigrationTester.swift
@@ -15,12 +15,94 @@ import VeinCore
 
 @MainActor
 public struct MigrationTester {
+    /// An error in the `SchemaMigrationPlan`
+    public enum Error: Swift.Error {
+        /// Schemas are not sorted oldest to newest.
+        case schemasNotSorted
+        /// Stages are not sorted oldest to newest or they contain a gap,
+        /// where rhs start version is not equal to lhs destination version.
+        ///
+        /// Vein requires
+        /// lhsStartSchema.version < rhsStartSchema.version AND
+        /// lhsDestinationSchema == rhsStartSchema AND
+        /// rhsDestinationSchema.version > rhsStartSchema.version
+        case stagesNotSortedOrWithGaps
+        /// A `SchemaMigrationPlan` is required to have at least one schema.
+        case mustContainSchema
+        /// The first migration stage must start at the first schema.
+        case firstStageMustStartAtFirstSchema
+        /// The last migration stage must end with the last schema.
+        case lastStageMustEndWithLastSchema
+        /// A stage uses a schema not part of schemas.
+        case usesUnknownSchema(any VersionedSchema.Type, in: MigrationStage)
+        /// There must be one less stage than there are schemas.
+        case invalidNumberOfMigrationStages
+        case _unknownStageType
+    }
+
     private let migrationPlan: any SchemaMigrationPlan.Type
     private let id = UUID()
     public let containerPath: String
 
     public init(migrationPlan: any SchemaMigrationPlan.Type) throws {
         self.migrationPlan = migrationPlan
+
+        guard migrationPlan.schemas.isSorted(by: { $0.version < $1.version }) else {
+            throw Error.schemasNotSorted
+        }
+
+        guard migrationPlan.stages.isSorted(by: {
+            guard
+                case .complex(let lhsStartSchema, let lhsDestinationSchema, _, _) = $0,
+                case .complex(let rhsStartSchema, let rhsDestinationSchema, _, _) = $1
+            else { return false }
+
+            return lhsStartSchema.version < rhsStartSchema.version
+                && lhsDestinationSchema == rhsStartSchema
+                && rhsDestinationSchema.version > rhsStartSchema.version
+        }) else {
+            throw Error.stagesNotSortedOrWithGaps
+        }
+
+        guard migrationPlan.schemas.count > 0 else {
+            throw Error.mustContainSchema
+        }
+
+        guard migrationPlan.stages.count == migrationPlan.schemas.count - 1 else {
+            throw Error.invalidNumberOfMigrationStages
+        }
+
+        if migrationPlan.schemas.count > 1 {
+            guard
+                let firstSchema = migrationPlan.schemas.first,
+                case .complex(let startSchema, _, _, _) = migrationPlan.stages.first,
+                firstSchema == startSchema
+            else {
+                throw Error.firstStageMustStartAtFirstSchema
+            }
+
+            guard
+                let lastSchema = migrationPlan.schemas.last,
+                case .complex(_, let endSchema, _, _) = migrationPlan.stages.last,
+                lastSchema == endSchema
+            else {
+                throw Error.lastStageMustEndWithLastSchema
+            }
+        }
+
+        for stage in migrationPlan.stages {
+            guard case .complex(let startSchema, let endSchema, _, _) = stage else {
+                throw Error._unknownStageType
+            }
+            guard migrationPlan.schemas.contains(where: { $0 == startSchema }) else {
+                throw Error.usesUnknownSchema(startSchema, in: stage)
+            }
+
+            guard migrationPlan.schemas.contains(where: { $0 == endSchema }) else {
+                throw Error.usesUnknownSchema(endSchema, in: stage)
+            }
+        }
+
         self.containerPath = try Self.prepareContainerLocation(
             plan: migrationPlan,
             id: id
@@ -62,10 +144,9 @@ public struct MigrationTester {
         initialData: (ManagedObjectContext) throws -> Void,
         validations: [ModelVersion: (ManagedObjectContext) throws -> Void]
     ) throws {
-        let sortedSchemas = migrationPlan.schemas
-            .sorted(by: { $0.version < $1.version})
+        let schemas = migrationPlan.schemas
         guard
-            let startingVersion = sortedSchemas.first
+            let startingVersion = schemas.first
         else {
             throw ManagedObjectContextError
                 .other(message: "\(migrationPlan) doesn't have any schemas")
@@ -82,7 +163,7 @@ public struct MigrationTester {
         try initialData(container.context)
         try validations[startingVersion.version]?(container.context)
 
-        for schema in sortedSchemas.dropFirst() {
+        for schema in schemas.dropFirst() {
             let currentContainer = try ModelContainer(
                 schema,
                 migration: migrationPlan,
@@ -124,5 +205,61 @@ public struct MigrationTester {
         }
 
         return dbPath
+    }
+}
+
+fileprivate extension Array {
+    func isSorted(by sorter: (_ lhs: Element, _ rhs: Element) -> Bool) -> Bool {
+        guard
+            var current = self.first,
+            count >= 2
+        else { return true }
+
+        for element in self[1...] {
+            guard sorter(current, element) else {
+                return false
+            }
+            current = element
+        }
+
+        return true
+    }
+}
+
+extension MigrationTester.Error: @MainActor Equatable {
+    @MainActor
+    public static func == (lhs: MigrationTester.Error, rhs: MigrationTester.Error) -> Bool {
+        switch (lhs, rhs) {
+            case (
+            usesUnknownSchema(let lhsSchema, let lhsMigrationStage),
+            usesUnknownSchema(let rhsSchema, let rhsMigrationStage)
+        ):
+                return lhsSchema == rhsSchema && lhsMigrationStage == rhsMigrationStage
+            case
+            (.schemasNotSorted, .schemasNotSorted),
+            (.stagesNotSortedOrWithGaps, .stagesNotSortedOrWithGaps),
+            (.mustContainSchema, .mustContainSchema),
+            (.firstStageMustStartAtFirstSchema, .firstStageMustStartAtFirstSchema),
+            (.lastStageMustEndWithLastSchema, .lastStageMustEndWithLastSchema),
+            (.invalidNumberOfMigrationStages, .invalidNumberOfMigrationStages),
+            (._unknownStageType, ._unknownStageType):
+                return true
+            default: return false
+        }
+    }
+}
+
+/// This conformance is not fully correct, it only checks the schemas.
+/// Do not use this yourself.
+extension MigrationStage: @MainActor Equatable {
+    public static func == (lhs: Vein.MigrationStage, rhs: Vein.MigrationStage) -> Bool {
+        switch (lhs, rhs) {
+            case (
+            .complex(let lhsStartSchema, let lhsEndSchema, _, _),
+            .complex(let rhsStartSchema, let rhsEndSchema, _, _)
+        ):
+                return lhsStartSchema == rhsStartSchema && lhsEndSchema == rhsEndSchema
+        }
+
     }
 }

--- a/Tests/VeinTestingTests/MigrationVerification.swift
+++ b/Tests/VeinTestingTests/MigrationVerification.swift
@@ -1,0 +1,405 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
+import Foundation
+import Testing
+@testable import VeinTesting
+import Vein
+#if TEST_SWIFTUI
+    import VeinSwiftUI
+#elseif !TEST_SWIFTUI
+    import VeinCore
+#endif
+
+@MainActor
+struct MigrationVerification {
+    @Test
+    func unsortedSchemasThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: UnsortedSchemasPlan.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.schemasNotSorted)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func unsortedStagesThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: UnsortedStagesPlan.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.stagesNotSortedOrWithGaps)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func gappedStagesThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: GappedStagesPlan.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.stagesNotSortedOrWithGaps)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func noSchemaThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: NoSchemaPlan.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.mustContainSchema)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func firstStageMustStartAtFirstSchemaThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: FirstStageNotStartingAtFirstSchema.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.firstStageMustStartAtFirstSchema)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func lastStageMustEndAtLastSchemaThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: LastStageNotEndingAtLastSchema.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.lastStageMustEndWithLastSchema)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func usesUnknownSchemaThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: UsesUnknownSchema.self)
+        } catch let error as MigrationTester.Error {
+            let migrationStage = Vein.MigrationStage.complex(
+                fromVersion: Version0.self,
+                toVersion: Version1.self,
+                willMigrate: nil,
+                didMigrate: nil
+            )
+            #expect(
+                error == MigrationTester.Error.usesUnknownSchema(
+                    Version1.self,
+                    in: migrationStage
+                )
+            )
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+
+    @Test
+    func invalidNumberOfMigrationStagesThrows() async throws {
+        do {
+            _ = try MigrationTester(migrationPlan: InvalidNumberOfStages.self)
+        } catch let error as MigrationTester.Error {
+            #expect(error == MigrationTester.Error.invalidNumberOfMigrationStages)
+            return
+        }
+        Issue.record("Unexpectedly no error was thrown.")
+    }
+}
+
+fileprivate enum Version0: VersionedSchema {
+    static let version = ModelVersion(0, 9, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self
+    ]}
+
+    @Model
+    final class User {}
+}
+
+fileprivate enum Version1: VersionedSchema {
+    static let version = ModelVersion(1, 0, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self
+    ]}
+
+    @Model
+    final class User {}
+}
+
+fileprivate enum Version2: VersionedSchema {
+    static let version = ModelVersion(1, 1, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self
+    ]}
+
+    @Model
+    final class User {}
+}
+
+fileprivate enum Version3: VersionedSchema {
+    static let version = ModelVersion(1, 2, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self
+    ]}
+
+    @Model
+    final class User {}
+}
+
+fileprivate enum Version4: VersionedSchema {
+    static let version = ModelVersion(1, 3, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self
+    ]}
+
+    @Model
+    final class User {}
+}
+
+fileprivate enum Version5: VersionedSchema {
+    static let version = ModelVersion(1, 4, 0)
+    static var models: [any Vein.PersistentModel.Type] {[
+        User.self
+    ]}
+
+    @Model
+    final class User {}
+}
+
+fileprivate enum UnsortedSchemasPlan: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self,
+        Version2.self,
+        Version4.self,
+        Version3.self
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[
+        v1ToV2,
+        v2ToV3,
+        v3ToV4
+    ]}
+
+    static let v1ToV2 = Vein.MigrationStage.complex(
+        fromVersion: Version1.self,
+        toVersion: Version2.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v2ToV3 = Vein.MigrationStage.complex(
+        fromVersion: Version2.self,
+        toVersion: Version3.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v3ToV4 = Vein.MigrationStage.complex(
+        fromVersion: Version3.self,
+        toVersion: Version4.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+}
+
+fileprivate enum UnsortedStagesPlan: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self,
+        Version2.self,
+        Version3.self,
+        Version4.self,
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[
+        v1ToV2,
+        v3ToV4,
+        v2ToV3,
+    ]}
+
+    static let v1ToV2 = Vein.MigrationStage.complex(
+        fromVersion: Version1.self,
+        toVersion: Version2.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v2ToV3 = Vein.MigrationStage.complex(
+        fromVersion: Version2.self,
+        toVersion: Version3.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v3ToV4 = Vein.MigrationStage.complex(
+        fromVersion: Version3.self,
+        toVersion: Version4.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+}
+
+fileprivate enum GappedStagesPlan: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self,
+        Version2.self,
+        Version3.self,
+        Version4.self,
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[
+        v1ToV2,
+        v3ToV4,
+    ]}
+
+    static let v1ToV2 = Vein.MigrationStage.complex(
+        fromVersion: Version1.self,
+        toVersion: Version2.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v3ToV4 = Vein.MigrationStage.complex(
+        fromVersion: Version3.self,
+        toVersion: Version4.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+}
+
+fileprivate enum NoSchemaPlan: SchemaMigrationPlan {
+    static let schemas: [any Vein.VersionedSchema.Type] = []
+    static var stages: [Vein.MigrationStage] = []
+}
+
+fileprivate enum FirstStageNotStartingAtFirstSchema: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self,
+        Version2.self,
+        Version3.self,
+        Version4.self,
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[
+        v0ToV2,
+        v2ToV3,
+        v3ToV4,
+    ]}
+
+    static let v0ToV2 = Vein.MigrationStage.complex(
+        fromVersion: Version0.self,
+        toVersion: Version2.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v2ToV3 = Vein.MigrationStage.complex(
+        fromVersion: Version2.self,
+        toVersion: Version3.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v3ToV4 = Vein.MigrationStage.complex(
+        fromVersion: Version3.self,
+        toVersion: Version4.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+}
+
+fileprivate enum LastStageNotEndingAtLastSchema: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version1.self,
+        Version2.self,
+        Version3.self,
+        Version4.self,
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[
+        v1ToV2,
+        v2ToV3,
+        v3ToV5
+    ]}
+
+    static let v1ToV2 = Vein.MigrationStage.complex(
+        fromVersion: Version1.self,
+        toVersion: Version2.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v2ToV3 = Vein.MigrationStage.complex(
+        fromVersion: Version2.self,
+        toVersion: Version3.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v3ToV5 = Vein.MigrationStage.complex(
+        fromVersion: Version3.self,
+        toVersion: Version5.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+}
+
+fileprivate enum UsesUnknownSchema: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version0.self,
+        Version2.self,
+        Version3.self,
+        Version4.self,
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[
+        v0ToV1,
+        v1ToV3,
+        v3ToV4,
+    ]}
+
+    static let v0ToV1 = Vein.MigrationStage.complex(
+        fromVersion: Version0.self,
+        toVersion: Version1.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v1ToV3 = Vein.MigrationStage.complex(
+        fromVersion: Version1.self,
+        toVersion: Version3.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+
+    static let v3ToV4 = Vein.MigrationStage.complex(
+        fromVersion: Version3.self,
+        toVersion: Version4.self,
+        willMigrate: nil,
+        didMigrate: nil
+    )
+}
+
+fileprivate enum InvalidNumberOfStages: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {[
+        Version0.self,
+        Version2.self,
+    ]}
+
+    static var stages: [Vein.MigrationStage] {[]}
+}

--- a/Tests/VeinTestingTests/StepByStep.swift
+++ b/Tests/VeinTestingTests/StepByStep.swift
@@ -12,8 +12,7 @@
 
 import Foundation
 import Testing
-@testable import VeinTesting
-import Vein
+import VeinTesting
 #if TEST_SWIFTUI
     import VeinSwiftUI
 #elseif !TEST_SWIFTUI


### PR DESCRIPTION
Resolves #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new migration testing tutorial and TOC entry, with step-by-step and full-chain examples that walk through validating schema migrations in practice.

Improved `MigrationTester` with stronger plan validation and clearer errors for malformed migration plans, plus `Equatable` support to make error assertions easier in tests.

Added comprehensive migration verification tests covering invalid plans, and expanded tutorial resources to demonstrate both incremental and end-to-end migration checks. Nice addition: the new tests and tutorial examples make the migration workflow much easier to understand and validate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->