### PR TITLE
added cli example & exported import Foundation due to requirement of Model macro

### DIFF
--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   linux:
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: swift:6.3.2-noble
     steps:
@@ -22,3 +22,11 @@ jobs:
       - name: Test
         # Disable encryption for testing purposes if needed
         run: ./Scripts/tsan-test.sh
+  build-example:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: Build FacetCLI
+        run: ./Scripts/build-cli-examples.sh

--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -24,6 +24,8 @@ jobs:
         run: ./Scripts/tsan-test.sh
   build-example:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: swift:6.3.2-noble
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:

--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -20,3 +20,11 @@ jobs:
         run: ./Scripts/tsan-test.sh
       - name: Test VeinSwiftUI
         run: IS_RUNNING_HEADLESS=1 TEST_SWIFTUI=1 ./Scripts/tsan-test.sh
+  build-example:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: Build FacetCLI
+        run: ./Scripts/build-cli-examples.sh

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,7 +22,7 @@ included:
   - Sources
   - Examples
 excluded:
-  - Examples/.build
+  - Examples/CliExample/.build
   - Sources/ULID
   - Tests/ULIDTests
   - Sources/VeinCore/VeinCore.docc

--- a/Examples/CliExample/Package.swift
+++ b/Examples/CliExample/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Examples/CliExample/Package.swift
+++ b/Examples/CliExample/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "FacetCLI",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(path: "../../"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "facet",
+            dependencies: [
+                .product(name: "VeinCore", package: "vein"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Examples/CliExample/Sources/facet/FacetCLI.swift
+++ b/Examples/CliExample/Sources/facet/FacetCLI.swift
@@ -98,7 +98,10 @@ extension FacetCLI {
                         let input = readLine()?
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                         .lowercased()
-                    else { continue }
+                    else {
+                        print("No input received. Aborting.")
+                        return
+                    }
 
                     if input == "y" || input == "yes" {
                         facet.name = name
@@ -294,13 +297,15 @@ extension FacetCLI {
                     )
                 }
 
-                FileManager.default.createFile(
+                let result = FileManager.default.createFile(
                     atPath: path,
                     contents: string.data(using: .utf8),
                     attributes: nil
                 )
-
-                count += 1
+                
+                if result {
+                    count += 1
+                }
             }
 
             print("\(count) files updated.")
@@ -326,7 +331,38 @@ extension FacetCLI {
     }
 
     struct Delete: AsyncParsableCommand {
-
+        @Argument(
+            help: "The short of the Facet you want to delete."
+        )
+        var short: String
+        
+        func run() async throws {
+            let container = try await makeModelContainer()
+            
+            let facets = try container.context.fetchAll(
+                #Predicate<Facet> {
+                    $0.short == short
+                }
+            )
+            
+            guard !facets.isEmpty else {
+                print("No results for short '\(short)'.")
+                return
+            }
+            
+            guard facets.count == 1 else {
+                print("Multiple matches for short '\(short)'.")
+                return
+            }
+            
+            guard let facet = facets.first else {
+                print("How did we get here?")
+                return
+            }
+            
+            try container.context.delete(facet)
+            try container.context.save()
+        }
     }
 
     static func renderAsList(input: [String: [String]], order: [String]) throws -> String {

--- a/Examples/CliExample/Sources/facet/FacetCLI.swift
+++ b/Examples/CliExample/Sources/facet/FacetCLI.swift
@@ -1,0 +1,389 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
+import ArgumentParser
+import VeinCore
+
+@main
+struct FacetCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "facet",
+        abstract: "A utility for applying regex replace to Swift files.",
+        subcommands: [Save.self, List.self, Get.self, Apply.self, Delete.self]
+    )
+}
+
+extension FacetCLI {
+    enum Error: Swift.Error {
+        case noApplicationSupportDirectory
+        case listExpectsEqualCountsForEachColumn
+        case invalidRegEx(String)
+    }
+
+    static func makeModelContainer() async throws -> ModelContainer {
+        guard
+            let applicationSupportDir = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first
+        else {
+            throw Error.noApplicationSupportDirectory
+        }
+
+        let facetDir = applicationSupportDir.appendingPathComponent("facet-cli")
+
+        if !FileManager.default.fileExists(atPath: facetDir.path()) {
+            try FileManager.default.createDirectory(at: facetDir, withIntermediateDirectories: true)
+        }
+
+        let dbPath = facetDir.appendingPathComponent("db.sqlite3")
+
+        let modelContainer = try ModelContainer(
+            V1_0_0.self,
+            migration: Migration.self,
+            at: dbPath.path(),
+            appID: "de.amethystsoft.facet-cli",
+            encryptionEnabled: false
+        )
+
+        let task = Task { @MainActor in
+            try modelContainer.migrate()
+        }
+        try await task.value
+
+        return modelContainer
+    }
+
+    struct Save: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "save",
+            abstract: "Store a new regex-replace combination (Facet)."
+        )
+
+        @Argument(
+            help: "A short unique identifier for the regex-replace combination you use to run it."
+        )
+        var short: String
+
+        @Argument(help: "The name of the new regex-replace combination.")
+        var name: String
+
+        @Argument(help: "The regular expression you want to save.")
+        var regex: String
+
+        @Argument(help: "The replacement you want to save.")
+        var replacement: String
+
+        func run() async throws {
+            let container = try await makeModelContainer()
+
+            if let facet = try container.context.fetchAll(
+                #Predicate<Facet> { $0.short == short }
+            ).first {
+                print(
+                    "A facet with the short '\(short)' already exists. Do you want to replace it? (y/n)"
+                )
+
+                while true {
+                    guard
+                        let input = readLine()?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .lowercased()
+                    else { continue }
+
+                    if input == "y" || input == "yes" {
+                        facet.name = name
+                        facet.regex = regex
+                        facet.replacement = replacement
+
+                        try container.context.save()
+                        return
+                    } else if input == "n" || input == "no" {
+                        return
+                    }
+
+                    print("Invalid input. Please enter 'y' or 'n'.")
+                }
+            }
+
+            let facet = Facet(
+                short: short,
+                name: name,
+                regex: regex,
+                replacement: replacement
+            )
+
+            try container.context.insert(facet)
+            try container.context.save()
+        }
+    }
+
+    struct List: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List all stored Facets."
+        )
+
+        @Option(help: "Filter the facets")
+        var filter: String?
+
+        func run() async throws {
+            let container = try await makeModelContainer()
+
+            var facets = [Facet]()
+
+            if let filter {
+                facets = try container.context.fetchAll(
+                    #Predicate<Facet> { facet in
+                        facet.name.contains(filter)
+                            || facet.short.contains(filter)
+                    }
+                )
+            } else {
+                facets = try container.context.fetchAll(Facet.self)
+            }
+
+            let result = try FacetCLI.renderAsList(
+                input: [
+                    "short": facets.map(\.short),
+                    "name": facets.map(\.name)
+                ],
+                order: [
+                    "short",
+                    "name"
+                ]
+            )
+
+            print(result)
+        }
+    }
+
+    struct Get: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "get",
+            abstract: "Get the Regex and its replacement for a given identifier."
+        )
+
+        @Argument(help: "The start of the Facet's short.")
+        var short: String
+
+        func run() async throws {
+            let container = try await makeModelContainer()
+
+            let facets = try container.context.fetchAll(
+                #Predicate<Facet> {
+                    $0.short.starts(with: short)
+                }
+            )
+
+            guard !facets.isEmpty else {
+                print("No results found for short '\(short)'.")
+                return
+            }
+
+            guard facets.count == 1 else {
+                print("More than one result for short '\(short)'.")
+                return
+            }
+
+            guard let facet = facets.first else {
+                print("How did we get here?")
+                return
+            }
+
+            print("Regex: '\(facet.regex)'")
+            print("Replacement: '\(facet.replacement)'")
+        }
+    }
+
+    struct Apply: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "apply",
+            abstract: "Apply the regex & replace to all swift files of a subfolder."
+        )
+
+        @Argument(
+            help: "The path to the folder to apply the regex to.",
+            transform: URL.init(fileURLWithPath: )
+        )
+        var pathURL: URL
+
+        @Argument(
+            help: "The shorts of the Facets in the order you want them to be applied."
+        )
+        var shorts: [String]
+
+        mutating func validate() throws {
+            guard FileManager.default.fileExists(atPath: pathURL.path) else {
+                throw ValidationError("File does not exist at \(pathURL.path)")
+            }
+        }
+
+        func run() async throws {
+            let container = try await makeModelContainer()
+
+            var positions = [String: Int]()
+
+            for (index, short) in shorts.enumerated() {
+                positions[short] = index
+            }
+
+            let facets = try container.context.fetchAll(Facet.self)
+                .filter {
+                    shorts.contains($0.short)
+                }
+                .sorted {
+                    positions[$0.short]! < positions[$1.short]!
+                }
+
+            guard !facets.isEmpty else {
+                print("No facets for given shorts found.")
+                return
+            }
+
+            var isDirectory: ObjCBool = false
+
+            guard
+                FileManager.default.fileExists(
+                    atPath: pathURL.path(),
+                    isDirectory: &isDirectory
+                )
+            else {
+                print("No file or folder at path: \(pathURL.path())")
+                return
+            }
+
+            var filePathsToHandle = [String]()
+
+            if isDirectory.boolValue {
+                filePathsToHandle = try FileManager.default
+                    .contentsOfDirectory(
+                        atPath: pathURL.path()
+                    )
+                    .filter { $0.hasSuffix(".swift") }
+                    .map { pathURL.appendingPathComponent($0).path() }
+            } else {
+                filePathsToHandle = [pathURL.path()]
+            }
+
+            var count: Int = 0
+
+            for path in filePathsToHandle {
+                guard
+                    let content = FileManager.default.contents(atPath: path),
+                    var string = String(data: content, encoding: .utf8)
+                else {
+                    print("skipped")
+                    continue
+                }
+
+                for facet in facets {
+                    string = try transformWithRegex(
+                        input: string,
+                        regex: facet.regex,
+                        replacement: facet.replacement
+                    )
+                }
+
+                FileManager.default.createFile(
+                    atPath: path,
+                    contents: string.data(using: .utf8),
+                    attributes: nil
+                )
+
+                count += 1
+            }
+
+            print("\(count) files updated.")
+        }
+
+        func transformWithRegex(
+            input: String,
+            regex: String,
+            replacement: String
+        ) throws -> String {
+            guard let regex = try? NSRegularExpression(pattern: regex, options: []) else {
+                throw Error.invalidRegEx(regex)
+            }
+
+            let range = NSRange(input.startIndex..<input.endIndex, in: input)
+
+            return regex.stringByReplacingMatches(
+                in: input,
+                range: range,
+                withTemplate: replacement
+            )
+        }
+    }
+
+    struct Delete: AsyncParsableCommand {
+
+    }
+
+    static func renderAsList(input: [String: [String]], order: [String]) throws -> String {
+        var longestForKey = [String: Int]()
+        var count: Int?
+
+        for (key, values) in input {
+            longestForKey[key] = key.count
+
+            if count == nil {
+                count = values.count
+            } else {
+                guard count == values.count else {
+                    throw Error.listExpectsEqualCountsForEachColumn
+                }
+            }
+
+            for value in values {
+                longestForKey[key] = max(longestForKey[key]!, value.count)
+            }
+        }
+
+        var lineParts = [[String]]()
+
+        for i in 0..<count! {
+            var parts = [String]()
+
+            for key in order {
+                var part = input[key]![i]
+
+                let spacesNeeded = longestForKey[key]! - part.count
+                part += Array(repeating: " ", count: spacesNeeded)
+
+                parts.append(part)
+            }
+
+            lineParts.append(parts)
+        }
+
+        let firstLineParts = order.map {
+            var part = $0
+
+            let spacesNeeded = longestForKey[$0]! - part.count
+            part += Array(repeating: " ", count: spacesNeeded)
+
+            return part
+        }
+
+        var resultString = firstLineParts.joined(separator: " ┃ ")
+        resultString += "\n" + firstLineParts.map {
+            Array(repeating: "━", count: $0.count).joined()
+        }.joined(separator: "━╋━")
+
+        for linePart in lineParts {
+            resultString += "\n" + linePart.joined(separator: " ┃ ")
+        }
+
+        return resultString
+    }
+}

--- a/Examples/CliExample/Sources/facet/Models.swift
+++ b/Examples/CliExample/Sources/facet/Models.swift
@@ -1,0 +1,45 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
+import VeinCore
+
+typealias Facet = V1_0_0.Facet
+
+enum V1_0_0: VersionedSchema {
+    static let version = ModelVersion(1, 0, 0)
+
+    static let models: [any PersistentModel.Type] = [
+        Facet.self
+    ]
+
+    @Model
+    final class Facet {
+        var short: String
+        var name: String
+        var regex: String
+        var replacement: String
+
+        init(short: String, name: String, regex: String, replacement: String) {
+            self.short = short
+            self.name = name
+            self.regex = regex
+            self.replacement = replacement
+        }
+    }
+}
+
+enum Migration: SchemaMigrationPlan {
+    static let schemas: [any VersionedSchema.Type] = [
+        V1_0_0.self
+    ]
+    static let stages: [MigrationStage] = []
+}

--- a/Scripts/build-cli-examples.sh
+++ b/Scripts/build-cli-examples.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$(dirname "$0")"/../Examples/CliExample || exit 1
+
+swift build

--- a/Sources/Vein/ModelContext/ModelContainer.swift
+++ b/Sources/Vein/ModelContext/ModelContainer.swift
@@ -10,7 +10,7 @@
 //
 // ===----------------------------------------------------------------------===
 
-import Foundation
+@_exported import Foundation
 import SQLiteDB
 
 /// The primary entry point for managing database schema and storage.

--- a/Sources/VeinSwiftUI/ModelMacro.swift
+++ b/Sources/VeinSwiftUI/ModelMacro.swift
@@ -42,7 +42,7 @@
         extension,
         conformances: PersistentModel,
         Sendable,
-        ObservableObject,
+        Combine.ObservableObject,
         names: named(version),
         named(schema)
     )

--- a/Sources/VeinSwiftUIMacros/ModelMacro.swift
+++ b/Sources/VeinSwiftUIMacros/ModelMacro.swift
@@ -37,7 +37,7 @@ public struct ModelMacro: MemberMacro, ExtensionMacro, MemberAttributeMacro {
         )
 
         let specific = """
-            let objectWillChange = PassthroughSubject<Void, Never>()
+            let objectWillChange = Combine.PassthroughSubject<Void, Never>()
 
             var notifyOfChanges: () -> Void {
                 { [weak self] in
@@ -73,7 +73,7 @@ public struct ModelMacro: MemberMacro, ExtensionMacro, MemberAttributeMacro {
         let specific = try ExtensionDeclSyntax(
             """
             @MainActor
-            extension \(raw: type): ObservableObject { }
+            extension \(raw: type): Combine.ObservableObject { }
             """
         )
 

--- a/Tests/VeinTests/Macros/MacrosTests.swift
+++ b/Tests/VeinTests/Macros/MacrosTests.swift
@@ -268,7 +268,7 @@ struct MacrosTests {
                             Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         ]
 
-                        let objectWillChange = PassthroughSubject<Void, Never>()
+                        let objectWillChange = Combine.PassthroughSubject<Void, Never>()
 
                         var notifyOfChanges: () -> Void {
                             { [weak self] in
@@ -287,7 +287,7 @@ struct MacrosTests {
                     }
 
                     @MainActor
-                    extension Test: ObservableObject {
+                    extension Test: Combine.ObservableObject {
                     }
                     """,
                 macroSpecs: testMacros,
@@ -538,7 +538,7 @@ struct MacrosTests {
                             Vein.FieldInformation(String.sqliteTypeName, "test", true)
                         ]
 
-                        let objectWillChange = PassthroughSubject<Void, Never>()
+                        let objectWillChange = Combine.PassthroughSubject<Void, Never>()
 
                         var notifyOfChanges: () -> Void {
                             { [weak self] in
@@ -557,7 +557,7 @@ struct MacrosTests {
                     }
 
                     @MainActor
-                    extension Test: ObservableObject {
+                    extension Test: Combine.ObservableObject {
                     }
                     """,
                 macroSpecs: testMacros,


### PR DESCRIPTION
resolves #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a SwiftData-backed `FacetCLI` example with `save`, `list`, `get`, `apply`, and `delete` commands.
- Added schema versioning, migrations, regex-based file transformations, table rendering, and persistent storage.
- Added a build script and Linux/macOS CI jobs to verify the CLI example builds.
- Re-exported `Foundation` from `Vein` to support downstream use of the `@Model` macro.
- Updated SwiftLint exclusions for the new example package.

The CLI example is a particularly strong addition: it provides a practical end-to-end demonstration of Vein’s model functionality while being continuously validated in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->