### PR TITLE
Add workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Amethyst Vein
 
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-mac.yml?label=mac)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-linux.yml?label=linux)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-android.yml?label=android)
+
+
 ## Roadmap to 1.0
 - Take a look at currently open issues
 


### PR DESCRIPTION
Added GitHub Actions workflow status badges for macOS, Linux, and Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added GitHub Actions status badges to `README.md` for macOS, Linux, and Android workflows.
- Adjusted spacing around the badges for improved readability.

This is a clear, low-impact documentation improvement that makes CI status more visible to contributors and users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->