### PR TITLE
adding windows CI

### DIFF
--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -1,0 +1,45 @@
+name: Swift Windows CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test-windows:
+    name: Test on Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Swift
+        uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 #1.14.0
+        with:
+          swift-version: "6.3.2"
+      # Prevent NTFS long path/case sensitivity quirks during CI
+      - name: Configure Git for Windows
+        run: git config --global core.protectNTFS false
+
+      - name: Test
+        run: ./Scripts/test.sh
+  build-example:
+    runs-on: windows-latest
+    container:
+      image: swift:6.3.2-noble
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Swift
+        uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 #1.14.0
+        with:
+          swift-version: "6.3.2"
+      - name: Build FacetCLI
+        run: ./Scripts/build-cli-examples.sh

--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -23,11 +23,9 @@ jobs:
         uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 #1.14.0
         with:
           swift-version: "6.3.2"
-      # Prevent NTFS long path/case sensitivity quirks during CI
-      - name: Configure Git for Windows
-        run: git config --global core.protectNTFS false
 
       - name: Test
+        shell: bash
         run: ./Scripts/test.sh
   build-example:
     runs-on: windows-latest
@@ -41,4 +39,5 @@ jobs:
         with:
           swift-version: "6.3.2"
       - name: Build FacetCLI
+        shell: bash
         run: ./Scripts/build-cli-examples.sh

--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -31,8 +31,7 @@ jobs:
         run: ./Scripts/test.sh
   build-example:
     runs-on: windows-latest
-    container:
-      image: swift:6.3.2-noble
+    
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:

--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test-windows:
     name: Test on Windows
-    runs-on: windows-latest
+    runs-on: blacksmith-4vcpu-windows-2025
 
     steps:
       - name: Checkout Code
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: ./Scripts/test.sh
   build-example:
-    runs-on: windows-latest
+    runs-on: blacksmith-4vcpu-windows-2025
     
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-mac.yml?label=mac)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-linux.yml?label=linux)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-android.yml?label=android)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/amethystsoft/vein/swift-test-windows.yml?label=windows)
 
 ## Table of Contents
 - [What is Vein](#what)


### PR DESCRIPTION
resolves #87 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds Windows CI support via a new GitHub Actions workflow that:

- Runs on pushes and pull requests targeting `main`
- Tests the project on Windows with Swift 6.3.2
- Disables `core.protectNTFS` to avoid Windows path/case issues
- Pins action versions by commit SHA and restricts permissions to read-only contents

This is a strong, focused addition that improves cross-platform coverage and resolves issue `#87`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->