### PR TITLE
Added unit test for credstore and fixed ressource typo

### DIFF
--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -219,14 +219,14 @@ public actor ManagedObjectContext {
                 }
             #elseif canImport(WinSDK)
                 let ressource = "com.amethyst.vein.sqlcipher.\(appID)+\(fileName)"
-                if let key = WinCredential.retrieve(resource: ressource) {
+                if let key = WinCredential.retrieve(ressource: ressource) {
                     return key
                 } else if createIfMissing {
                     let keyData = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
                     let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
 
                     guard WinCredential.store(
-                        resource: ressource,
+                        ressource: ressource,
                         username: "veindbsecret",
                         secret: hexKey
                     ) else {

--- a/Sources/Vein/ModelContext/WindowsCredential.swift
+++ b/Sources/Vein/ModelContext/WindowsCredential.swift
@@ -64,18 +64,18 @@
             let secretData = Data(buffer: blobBuffer)
             return String(data: secretData, encoding: .utf16LittleEndian)
         }
-        
+
         static func delete(ressource: String) -> Bool {
             var resourceW = Array(ressource.utf16) + [0]
-            
+
             let success = resourceW.withUnsafeMutableBufferPointer { resBuffer in
                 CredDeleteW(resBuffer.baseAddress, DWORD(CRED_TYPE_GENERIC), 0)
             }
-            
+
             if !success {
                 let error = GetLastError()
                 print("Failed to delete credential. Windows Error Code: \(error)")
-                
+
                 if error == DWORD(ERROR_NOT_FOUND) {
                     // If it wasn't found there's nothing to delete.
                     return true

--- a/Sources/Vein/ModelContext/WindowsCredential.swift
+++ b/Sources/Vein/ModelContext/WindowsCredential.swift
@@ -15,8 +15,8 @@
     import Foundation
 
     enum WinCredential {
-        static func store(resource: String, username: String, secret: String) -> Bool {
-            var resourceW = Array(resource.utf16) + [0]
+        static func store(ressource: String, username: String, secret: String) -> Bool {
+            var resourceW = Array(ressource.utf16) + [0]
             var usernameW = Array(username.utf16) + [0]
 
             let secretData = secret.data(using: .utf16LittleEndian)!
@@ -43,8 +43,8 @@
             }
         }
 
-        static func retrieve(resource: String) -> String? {
-            var resourceW = Array(resource.utf16) + [0]
+        static func retrieve(ressource: String) -> String? {
+            var resourceW = Array(ressource.utf16) + [0]
             var credentialPointer: PCREDENTIALW? = nil
 
             let success = resourceW.withUnsafeMutableBufferPointer { resBuffer in

--- a/Sources/Vein/ModelContext/WindowsCredential.swift
+++ b/Sources/Vein/ModelContext/WindowsCredential.swift
@@ -64,5 +64,24 @@
             let secretData = Data(buffer: blobBuffer)
             return String(data: secretData, encoding: .utf16LittleEndian)
         }
+        
+        static func delete(ressource: String) -> Bool {
+            var resourceW = Array(ressource.utf16) + [0]
+            
+            let success = resourceW.withUnsafeMutableBufferPointer { resBuffer in
+                CredDeleteW(resBuffer.baseAddress, DWORD(CRED_TYPE_GENERIC), 0)
+            }
+            
+            if !success {
+                let error = GetLastError()
+                print("Failed to delete credential. Windows Error Code: \(error)")
+                
+                if error == DWORD(ERROR_NOT_FOUND) {
+                    // If it wasn't found there's nothing to delete.
+                    return true
+                }
+                return false
+            } else { return true }
+        }
     }
 #endif

--- a/Tests/VeinTests/Windows/CredStoreTests.swift
+++ b/Tests/VeinTests/Windows/CredStoreTests.swift
@@ -1,0 +1,24 @@
+#if canImport(WinSDK)
+@testable import Vein
+import Testing
+
+@Suite
+struct WinCredentialTest {
+	@Test
+	func ensureEncodeDecode() async throws {
+		let ressource = "de.amethystsoft.vein.WinCredentialTest"
+		let username = "VeinCredentialTest"
+		let secret = "test123-"
+		
+		WinCredential.store(
+			ressource: ressource,
+			username: username,
+			secret: secret
+		)
+		
+		let result = WinCredential.retrieve(ressource: ressource)
+		
+		#expect(secret == result)
+	}
+}
+#endif

--- a/Tests/VeinTests/Windows/CredStoreTests.swift
+++ b/Tests/VeinTests/Windows/CredStoreTests.swift
@@ -1,24 +1,36 @@
-#if canImport(WinSDK)
-@testable import Vein
-import Testing
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
 
-@Suite
-struct WinCredentialTest {
-	@Test
-	func ensureEncodeDecode() async throws {
-		let ressource = "de.amethystsoft.vein.WinCredentialTest"
-		let username = "VeinCredentialTest"
-		let secret = "test123-"
-		
-		WinCredential.store(
-			ressource: ressource,
-			username: username,
-			secret: secret
-		)
-		
-		let result = WinCredential.retrieve(ressource: ressource)
-		
-		#expect(secret == result)
-	}
-}
+#if canImport(WinSDK)
+    @testable import Vein
+    import Testing
+
+    @Suite
+    struct WinCredentialTest {
+        @Test
+        func ensureEncodeDecode() async throws {
+            let ressource = "de.amethystsoft.vein.WinCredentialTest"
+            let username = "VeinCredentialTest"
+            let secret = "test123-"
+
+            WinCredential.store(
+                ressource: ressource,
+                username: username,
+                secret: secret
+            )
+
+            let result = WinCredential.retrieve(ressource: ressource)
+
+            #expect(secret == result)
+        }
+    }
 #endif

--- a/Tests/VeinTests/Windows/CredStoreTests.swift
+++ b/Tests/VeinTests/Windows/CredStoreTests.swift
@@ -33,6 +33,9 @@
             let result = WinCredential.retrieve(ressource: ressource)
 
             #expect(secret == result)
+            
+            let deleteSucceeded = WinCredential.delete(ressource: ressource)
+            #expect(deleteSucceeded)
         }
     }
 #endif

--- a/Tests/VeinTests/Windows/CredStoreTests.swift
+++ b/Tests/VeinTests/Windows/CredStoreTests.swift
@@ -27,13 +27,13 @@
                 username: username,
                 secret: secret
             )
-            
+
             #expect(succeeded)
 
             let result = WinCredential.retrieve(ressource: ressource)
 
             #expect(secret == result)
-            
+
             let deleteSucceeded = WinCredential.delete(ressource: ressource)
             #expect(deleteSucceeded)
         }

--- a/Tests/VeinTests/Windows/CredStoreTests.swift
+++ b/Tests/VeinTests/Windows/CredStoreTests.swift
@@ -22,11 +22,13 @@
             let username = "VeinCredentialTest"
             let secret = "test123-"
 
-            WinCredential.store(
+            let succeeded = WinCredential.store(
                 ressource: ressource,
                 username: username,
                 secret: secret
             )
+            
+            #expect(succeeded)
 
             let result = WinCredential.retrieve(ressource: ressource)
 


### PR DESCRIPTION
Resolves #98 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a Windows-only unit test covering credential storage and retrieval.
- Fixed the Windows credential resource parameter typo consistently across the credential store and managed object context.
- The test validates that retrieved secrets match stored values, providing strong coverage for the credential-store flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->