### PR TITLE
Added caching to windows, linux and mac CI

### DIFF
--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -19,13 +19,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
+      - name: Cache Swift build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
       - name: Install dependencies
         run: |
           apt-get update
           apt-get install -y dbus-x11 gnome-keyring
       - name: Test VeinCore
         run: |
-          # Use dbus-run-session to wrap the test execution
           dbus-run-session -- sh -c '
             echo "test" | gnome-keyring-daemon --unlock --components=secrets
             ./Scripts/tsan-test.sh
@@ -37,6 +43,7 @@ jobs:
             TEST_SCUI=1 ./Scripts/tsan-test.sh
           '
   build-example:
+    needs: linux
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: swift:6.3.2-noble
@@ -44,5 +51,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
+      - name: Cache Swift build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
       - name: Build FacetCLI
         run: ./Scripts/build-cli-examples.sh

--- a/.github/workflows/swift-test-linux.yml
+++ b/.github/workflows/swift-test-linux.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,7 +48,7 @@ jobs:
           '
   build-example:
     needs: linux
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     container:
       image: swift:6.3.2-noble
     steps:

--- a/.github/workflows/swift-test-mac.yml
+++ b/.github/workflows/swift-test-mac.yml
@@ -16,18 +16,41 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
+
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm/
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Test VeinCore
         run: ./Scripts/tsan-test.sh
       - name: Test VeinSwiftUI
         run: IS_RUNNING_HEADLESS=1 TEST_SWIFTUI=1 ./Scripts/tsan-test.sh
       - name: Test VeinSCUI
         run: TEST_SCUI=1 ./Scripts/tsan-test.sh
+
   build-example:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
+
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm/
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Build FacetCLI
         run: ./Scripts/build-cli-examples.sh
       - name: Build SCUI Basic Example

--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -19,25 +19,51 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
+
       - name: Setup Swift
         uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 #1.14.0
         with:
           swift-version: "6.3.2"
 
+      - name: Cache Swift Build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            .swiftpm
+          key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+
       - name: Test VeinCore
         shell: bash
         run: ./Scripts/test.sh
+
   build-example:
+    name: Build Example
+    needs: [test-windows]
     runs-on: blacksmith-4vcpu-windows-2025
-    
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:
           persist-credentials: false
+
       - name: Setup Swift
         uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 #1.14.0
         with:
           swift-version: "6.3.2"
+
+      - name: Restore Swift Build Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .build
+            .swiftpm
+          key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+
       - name: Build FacetCLI
         shell: bash
         run: ./Scripts/build-cli-examples.sh

--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -42,7 +46,7 @@ jobs:
   build-example:
     name: Build Example
     needs: [test-windows]
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-2vcpu-windows-2025
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -3,4 +3,4 @@ EXTRA_ARGS=""
 if [ -n "$TEST_SCUI" ]; then
   EXTRA_ARGS="--traits VeinSCUI"
 fi
-SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts $EXTRA_ARGS
+SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts $EXTRA_ARGS --test-product amethyst-veinPackageTests

--- a/Scripts/tsan-test.sh
+++ b/Scripts/tsan-test.sh
@@ -3,4 +3,4 @@ EXTRA_ARGS=""
 if [ -n "$TEST_SCUI" ]; then
   EXTRA_ARGS="--traits VeinSCUI"
 fi
-TSAN_OPTIONS="suppressions=tsan_suppressions.txt" SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts --sanitize=thread $EXTRA_ARGS
+TSAN_OPTIONS="suppressions=tsan_suppressions.txt" SHOULD_DISABLE_ENCRYPTION=1 swift test --enable-experimental-prebuilts --sanitize=thread $EXTRA_ARGS --test-product amethyst-veinPackageTests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Swift build caching across Linux, macOS, and Windows CI workflows.
- Added concurrency controls to Linux and Windows workflows to cancel outdated runs.
- Updated example builds to run after tests and use appropriately sized runners.
- Explicitly targeted `amethyst-veinPackageTests` in standard and Thread Sanitizer test scripts.

The shared caching and concurrency improvements should reduce CI time and resource usage while preventing redundant runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->