### PR TITLE
Add key provider & stop running Windows CI on blacksmith

### DIFF
--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Test Swift Package on Android"
         uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
         with:
-          swift-version: '6.4'
+          swift-version: 'swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a'
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
           test-env: SHOULD_DISABLE_ENCRYPTION=1

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Test Swift Package on Android"
         uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
         with:
-          swift-version: 'swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a'
+          swift-version: 'nightly-6.4.x'
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
           test-env: SHOULD_DISABLE_ENCRYPTION=1

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Test Swift Package on Android"
         uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
         with:
-          swift-version: 'nightly-main'
+          swift-version: '6.4-snapshot'
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
           test-env: SHOULD_DISABLE_ENCRYPTION=1

--- a/.github/workflows/swift-test-android.yml
+++ b/.github/workflows/swift-test-android.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Test Swift Package on Android"
         uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
         with:
-          swift-version: '6.4-snapshot'
+          swift-version: '6.4'
           # Ubuntu runners low on space causes the emulator to fail to install
           free-disk-space: true
           test-env: SHOULD_DISABLE_ENCRYPTION=1

--- a/.github/workflows/swift-test-windows.yml
+++ b/.github/workflows/swift-test-windows.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test-windows:
     name: Test on Windows
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
 
     steps:
       - name: Checkout Code
@@ -28,8 +28,7 @@ jobs:
         shell: bash
         run: ./Scripts/test.sh
   build-example:
-    runs-on: blacksmith-4vcpu-windows-2025
-    
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
         with:

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ import Foundation
 #endif
 
 var veinDependencies: [Target.Dependency] = [
-    .product(name: "Crypto", package: "swift-crypto"),
     .product(name: "SQLiteDB", package: "swift-sqlcipher"),
     "ULID",
     .product(name: "Logging", package: "swift-log"),
@@ -83,7 +82,6 @@ let package = Package(
             url: "https://github.com/skiptools/swift-sqlcipher",
             .upToNextMajor(from: "1.11.0")
         ),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "610.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.9.1")),
         .package(

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We generally recommend not to save the same models on multiple threads concurren
 ### Dependency Footprint
 Vein is designed to be highly portable, relying on standard Swift Evolution tools, cross platform wrappers and platform specific tools (for storing encryption keys), to make usage as seemless as possible for you.
 
-- **Database & Security**: `skiptools/swift-sqlcipher` (cross platform sqlite and db level encryption), `apple/swift-crypto`
+- **Database & Security**: `skiptools/swift-sqlcipher` (cross platform sqlite and db level encryption)
 - **Credentials**: `kishikawakatsumi/keychainaccess` (Apple), `amethystsoft/KeyringAccess` (our own lib for storing credentials in SecretService on Linux) and a Vein internal wrapper for CredW from the WinSDK on windows. Currently we don't support db level encryption on android due to difficulties with storing keys safely caused by the way android is build.
 - **Metadata & Tooling**: `swiftlang/swift-syntax` (compile time macros), `apple/swift-log`, `apple/swift-atomics` (used only in a write once, read a lot place)
 - **Testing**: `typelift/SwiftCheck` for property based testing.

--- a/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
+++ b/Sources/Vein/Model/PropertyWrappers/OneRelationship.swift
@@ -208,14 +208,14 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
             #endif
         }) {
 
-            if var manyField = matchingField as? (any ManyRelationship) {
+            if let manyField = matchingField as? (any ManyRelationship) {
                 if isRemoving {
                     manyField._persistableValue.removeAll { $0 == model.id }
                 } else if !manyField._persistableValue.contains(model.id) {
                     manyField._persistableValue.append(model.id)
                 }
                 manyField.wasTouched = true
-            } else if var oneField = matchingField as? (any OneRelationship) {
+            } else if let oneField = matchingField as? (any OneRelationship) {
                 oneField._persistableValue = isRemoving ? nil : model.id
                 oneField.wasTouched = true
             }
@@ -317,10 +317,10 @@ public final class _OneRelationship<T: PersistentModel>: OneRelationship, @unche
 
                     let inverse = target._fields.first { $0.key == _inverseKey }
 
-                    if var manyField = inverse as? (any ManyRelationship) {
+                    if let manyField = inverse as? (any ManyRelationship) {
                         manyField._persistableValue.removeAll(where: { $0 == model.id })
                         manyField.wasTouched = true
-                    } else if var oneField = inverse as? (any OneRelationship) {
+                    } else if let oneField = inverse as? (any OneRelationship) {
                         oneField._persistableValue = nil
                         oneField.wasTouched = true
                     }

--- a/Sources/Vein/ModelContext/KeyProviders/IntegratedKeyProvider.swift
+++ b/Sources/Vein/ModelContext/KeyProviders/IntegratedKeyProvider.swift
@@ -41,7 +41,7 @@
 #elseif os(Linux)
     @_exported import KeyringAccess
 
-    public typealias IntegratedKeyProvider = KeychainKeyProvider
+    public typealias IntegratedKeyProvider = KeyringKeyProvider
     public struct KeyringKeyProvider: DatabaseKeyProvider {
         public static func getKey(
             fileName: String,

--- a/Sources/Vein/ModelContext/KeyProviders/IntegratedKeyProvider.swift
+++ b/Sources/Vein/ModelContext/KeyProviders/IntegratedKeyProvider.swift
@@ -56,7 +56,7 @@
                 let key = generate()
 
                 do {
-                    try keyring.set(key, key: fileName)
+                    try keyring.set(key, for: fileName)
                 } catch {
                     throw .providerError(error.localizedDescription)
                 }
@@ -84,7 +84,7 @@
                 guard WinCredential.store(
                     ressource: ressource,
                     username: "veindbsecret",
-                    secret: hexKey
+                    secret: key
                 ) else {
                     throw .providerError("Failed to store key.")
                 }

--- a/Sources/Vein/ModelContext/KeyProviders/IntegratedKeyProvider.swift
+++ b/Sources/Vein/ModelContext/KeyProviders/IntegratedKeyProvider.swift
@@ -1,0 +1,97 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
+#if canImport(AppKit) || canImport(UIKit)
+    import KeychainAccess
+
+    public typealias IntegratedKeyProvider = KeychainKeyProvider
+    public struct KeychainKeyProvider: DatabaseKeyProvider {
+        public static func getKey(
+            fileName: String,
+            service: String,
+            generate: (() -> String)?
+        ) throws(KeyProviderError) -> String {
+            let keychain = Keychain(service: service)
+
+            if let key = keychain[fileName] {
+                return key
+            } else if let generate {
+                let key = generate()
+
+                do {
+                    try keychain.set(key, key: fileName)
+                } catch {
+                    throw .providerError(error.localizedDescription)
+                }
+                return key
+            }
+
+            throw .noSuchKey
+        }
+    }
+#elseif os(Linux)
+    @_exported import KeyringAccess
+
+    public typealias IntegratedKeyProvider = KeychainKeyProvider
+    public struct KeyringKeyProvider: DatabaseKeyProvider {
+        public static func getKey(
+            fileName: String,
+            service: String,
+            generate: (() -> String)?
+        ) throws(KeyProviderError) -> String {
+            let keyring = Keyring(service: service)
+
+            if let key = keyring[fileName] {
+                return key
+            } else if let generate {
+                let key = generate()
+
+                do {
+                    try keyring.set(key, key: fileName)
+                } catch {
+                    throw .providerError(error.localizedDescription)
+                }
+                return key
+            }
+
+            throw .noSuchKey
+        }
+    }
+#elseif canImport(WinSDK)
+    public typealias IntegratedKeyProvider = WinCredentialKeyProvider
+    public struct WinCredentialKeyProvider: DatabaseKeyProvider {
+        public static func getKey(
+            fileName: String,
+            service: String,
+            generate: (() -> String)?
+        ) throws(KeyProviderError) -> String {
+            let ressource = "\(service)+\(fileName)"
+
+            if let key = WinCredential.retrieve(ressource: ressource) {
+                return key
+            } else if let generate {
+                let key = generate()
+
+                guard WinCredential.store(
+                    ressource: ressource,
+                    username: "veindbsecret",
+                    secret: hexKey
+                ) else {
+                    throw .providerError("Failed to store key.")
+                }
+                return key
+            }
+
+            throw .noSuchKey
+        }
+    }
+#endif

--- a/Sources/Vein/ModelContext/KeyProviders/KeyProviderProtocol.swift
+++ b/Sources/Vein/ModelContext/KeyProviders/KeyProviderProtocol.swift
@@ -1,0 +1,24 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
+public protocol DatabaseKeyProvider {
+    static func getKey(
+        fileName: String,
+        service: String,
+        generate: (() -> String)?
+    ) throws(KeyProviderError) -> String
+}
+
+public enum KeyProviderError: Error {
+    case noSuchKey
+    case providerError(String)
+}

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -120,7 +120,8 @@ public actor ManagedObjectContext {
                             }
                         )
                     else {
-                        throw ManagedObjectContextError.other(message: "Failed to retrieve/save key to encrypt Database.")
+                        throw ManagedObjectContextError
+                            .other(message: "Failed to retrieve/save key to encrypt Database.")
                     }
                     try self.connection.key(key)
                 }

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -97,19 +97,34 @@ public actor ManagedObjectContext {
             self.connection = try Connection(path)
             // That stuff can take 15s with TSAN enabled and compiled with Onone.
             // I confirmed its only an issue with TSAN.
-            #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
-                if modelContainer.encryptionEnabled {
+            if modelContainer.encryptionEnabled {
+                guard let path = modelContainer.path else {
+                    throw ManagedObjectContextError.other(
+                        message: "Encryption is only supported on disk-stored databases."
+                    )
+                }
+                let service = "com.amethyst.vein.sqlcipher.\(modelContainer.appID)"
+                let url = URL(fileURLWithPath: path)
+                let fileName = url.lastPathComponent
+
+                try Self.keyLock.withLock {
                     guard
-                        let key = Self.getKeyForDatabase(
-                            at: path,
-                            appID: modelContainer.appID
+                        let key = try modelContainer.keyProvider?.getKey(
+                            fileName: fileName,
+                            service: service,
+                            generate: {
+                                let keyData = SymmetricKey(size: .bits256)
+                                    .withUnsafeBytes { Data($0) }
+                                let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
+                                return hexKey
+                            }
                         )
                     else {
                         fatalError("Vein: Failed to retrieve/save key to encrypt Database.")
                     }
                     try self.connection.key(key)
                 }
-            #endif
+            }
 
             try self.connection.execute("PRAGMA journal_mode=WAL;")
         } catch let error as SQLiteDB.Result {
@@ -157,85 +172,16 @@ public actor ManagedObjectContext {
         else {
             return nil
         }
-        return Self.getKeyForDatabase(
-            at: path,
-            appID: modelContainer.appID,
-            createIfMissing: false
-        )
-    }
+        let service = "com.amethyst.vein.sqlcipher.\(modelContainer.appID)"
+        let url = URL(fileURLWithPath: path)
+        let fileName = url.lastPathComponent
 
-    /// Accesses the encryption key for a specific database file without requiring an active database connection.
-    ///
-    /// This static method allows you to retrieve or generate encryption keys by providing the file path
-    /// and application identifier. While the instance method `getDatabaseKey()` is preferred for
-    /// active contexts, this method is useful for utility tasks or pre-initialization checks.
-    ///
-    /// - Parameters:
-    ///   - path: The absolute file path to the database. The filename is used as the key identifier in the secure store.
-    ///   - appID: The unique application identifier used to namespace the Keychain or Keyring service.
-    ///   - createIfMissing: If `true`, a new 256-bit AES key will be generated and persisted if one
-    ///     does not already exist. Set this to `false` if you only want to verify the existence of a key.
-    ///
-    /// - Note: On Apple platforms, this utilizes the System Keychain. On Linux, it utilizes the
-    ///   system Keyring.
-    ///
-    /// - Returns: A hex-encoded 256-bit key string if found or successfully created; otherwise, `nil`.
-    public static func getKeyForDatabase(
-        at path: String,
-        appID: String,
-        createIfMissing: Bool = true
-    ) -> String? {
-        return keyLock.withLock {
-            let url = URL(fileURLWithPath: path)
-            let fileName = url.lastPathComponent
-
-            #if canImport(AppKit) || canImport(UIKit)
-                let keychain = Keychain(service: "com.amethyst.vein.sqlcipher.\(appID)")
-
-                if let key = keychain[fileName] {
-                    return key
-                } else if createIfMissing {
-                    let keyData = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
-                    let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
-
-                    guard (try? keychain.set(hexKey, key: fileName)) != nil else {
-                        return nil
-                    }
-                    return hexKey
-                }
-            #elseif os(Linux)
-                let keyring = Keyring(service: "com.amethyst.vein.sqlcipher.\(appID)")
-
-                if let key = keyring[fileName] {
-                    return key
-                } else if createIfMissing {
-                    let keyData = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
-                    let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
-
-                    guard (try? keyring.set(hexKey, for: fileName)) != nil else {
-                        return nil
-                    }
-                    return hexKey
-                }
-            #elseif canImport(WinSDK)
-                let ressource = "com.amethyst.vein.sqlcipher.\(appID)+\(fileName)"
-                if let key = WinCredential.retrieve(ressource: ressource) {
-                    return key
-                } else if createIfMissing {
-                    let keyData = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
-                    let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
-
-                    guard WinCredential.store(
-                        ressource: ressource,
-                        username: "veindbsecret",
-                        secret: hexKey
-                    ) else {
-                        return nil
-                    }
-                    return hexKey
-                }
-            #endif
-            return nil
+        return Self.keyLock.withLock {
+            return try? modelContainer.keyProvider?.getKey(
+                fileName: fileName,
+                service: service,
+                generate: nil
+            )
         }
     }
 }

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -13,7 +13,6 @@
 import SQLiteDB
 import Foundation
 import ULID
-import Crypto
 import Logging
 import Atomics
 #if canImport(AppKit) || canImport(UIKit)
@@ -113,8 +112,14 @@ public actor ManagedObjectContext {
                             fileName: fileName,
                             service: service,
                             generate: {
-                                let keyData = SymmetricKey(size: .bits256)
-                                    .withUnsafeBytes { Data($0) }
+                                var generator = SystemRandomNumberGenerator()
+                                let keyParts = [
+                                    generator.next(),
+                                    generator.next(),
+                                    generator.next(),
+                                    generator.next()
+                                ]
+                                let keyData = keyParts.withUnsafeBytes { Data($0) }
                                 let hexKey = keyData.map { String(format: "%02hhx", $0) }.joined()
                                 return hexKey
                             }

--- a/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
+++ b/Sources/Vein/ModelContext/ManagedObjectContext/ManagedObjectContext.swift
@@ -120,7 +120,7 @@ public actor ManagedObjectContext {
                             }
                         )
                     else {
-                        fatalError("Vein: Failed to retrieve/save key to encrypt Database.")
+                        throw ManagedObjectContextError.other(message: "Failed to retrieve/save key to encrypt Database.")
                     }
                     try self.connection.key(key)
                 }

--- a/Sources/Vein/ModelContext/ModelContainer.swift
+++ b/Sources/Vein/ModelContext/ModelContainer.swift
@@ -44,6 +44,9 @@ public final class ModelContainer: @unchecked Sendable {
     /// The logging verbosity for database operations.
     public let logConfiguration: LogConfiguration
 
+    /// The structure providing and storing the database key if encryption is enabled.
+    public let keyProvider: (any DatabaseKeyProvider.Type)?
+
     /// Manages the schema and storage for a Vein database.
     ///
     /// - Parameters:
@@ -53,6 +56,7 @@ public final class ModelContainer: @unchecked Sendable {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -81,6 +85,7 @@ public final class ModelContainer: @unchecked Sendable {
         at path: String?,
         appID: String,
         encryptionEnabled: Bool,
+        keyProvider: (any DatabaseKeyProvider.Type)?,
         logConfiguration: LogConfiguration?,
         _notifyBeforeChange: Bool
     ) throws(ManagedObjectContextError) {
@@ -100,6 +105,7 @@ public final class ModelContainer: @unchecked Sendable {
             #endif
         }
         self.encryptionEnabled = encryptionEnabled
+        self.keyProvider = keyProvider
         self.appID = appID
 
         guard migration.schemas.contains(where: { $0.self == versionedSchema }) else {
@@ -159,6 +165,7 @@ public final class ModelContainer: @unchecked Sendable {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -187,6 +194,7 @@ public final class ModelContainer: @unchecked Sendable {
         connection: Connection,
         appID: String,
         encryptionEnabled: Bool,
+        keyProvider: (any DatabaseKeyProvider.Type)?,
         logConfiguration: LogConfiguration?,
         _notifyBeforeChange: Bool
     ) throws(ManagedObjectContextError) {
@@ -207,6 +215,7 @@ public final class ModelContainer: @unchecked Sendable {
         }
 
         self.encryptionEnabled = encryptionEnabled
+        self.keyProvider = keyProvider
         self.appID = appID
 
         guard migration.schemas.contains(where: { $0.self == versionedSchema }) else {

--- a/Sources/VeinCore/ModelContainer.swift
+++ b/Sources/VeinCore/ModelContainer.swift
@@ -71,7 +71,7 @@ extension ModelContainer {
             at path: String?,
             appID: String,
             encryptionEnabled: Bool = true,
-            keyProvider: (any DatabaseKeyProvider.Type)?,
+            keyProvider: (any DatabaseKeyProvider.Type)? = nil,
             logConfiguration: LogConfiguration? = nil
         ) throws(ManagedObjectContextError) {
             try self.init(
@@ -145,7 +145,7 @@ extension ModelContainer {
             connection: Connection,
             appID: String,
             encryptionEnabled: Bool = true,
-            keyProvider: (any DatabaseKeyProvider.Type)?,
+            keyProvider: (any DatabaseKeyProvider.Type)? = nil,
             logConfiguration: LogConfiguration? = nil
         ) throws(ManagedObjectContextError) {
             try self.init(

--- a/Sources/VeinCore/ModelContainer.swift
+++ b/Sources/VeinCore/ModelContainer.swift
@@ -22,6 +22,7 @@ extension ModelContainer {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -42,24 +43,49 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    public convenience init(
-        _ versionedSchema: VersionedSchema.Type,
-        migration: SchemaMigrationPlan.Type,
-        at path: String?,
-        appID: String,
-        encryptionEnabled: Bool = true,
-        logConfiguration: LogConfiguration? = nil
-    ) throws(ManagedObjectContextError) {
-        try self.init(
-            versionedSchema,
-            migration: migration,
-            at: path,
-            appID: appID,
-            encryptionEnabled: encryptionEnabled,
-            logConfiguration: logConfiguration,
-            _notifyBeforeChange: false
-        )
-    }
+    #if !os(Android)
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            at path: String?,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)? = Vein.IntegratedKeyProvider.self,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                at: path,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #else
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            at path: String?,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)?,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                at: path,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #endif
 
     /// Manages the schema and storage for a Vein database.
     ///
@@ -70,6 +96,7 @@ extension ModelContainer {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -90,22 +117,47 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    public convenience init(
-        _ versionedSchema: VersionedSchema.Type,
-        migration: SchemaMigrationPlan.Type,
-        connection: Connection,
-        appID: String,
-        encryptionEnabled: Bool = true,
-        logConfiguration: LogConfiguration? = nil
-    ) throws(ManagedObjectContextError) {
-        try self.init(
-            versionedSchema,
-            migration: migration,
-            connection: connection,
-            appID: appID,
-            encryptionEnabled: encryptionEnabled,
-            logConfiguration: logConfiguration,
-            _notifyBeforeChange: false
-        )
-    }
+    #if !os(Android)
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            connection: Connection,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)? = Vein.IntegratedKeyProvider.self,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                connection: connection,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #else
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            connection: Connection,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)?,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                connection: connection,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #endif
 }

--- a/Sources/VeinCore/ModelContainer.swift
+++ b/Sources/VeinCore/ModelContainer.swift
@@ -43,7 +43,7 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    #if !os(Android)
+    #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
         public convenience init(
             _ versionedSchema: VersionedSchema.Type,
             migration: SchemaMigrationPlan.Type,
@@ -117,7 +117,7 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    #if !os(Android)
+    #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
         public convenience init(
             _ versionedSchema: VersionedSchema.Type,
             migration: SchemaMigrationPlan.Type,

--- a/Sources/VeinSCUI/ModelContainer.swift
+++ b/Sources/VeinSCUI/ModelContainer.swift
@@ -71,7 +71,7 @@ extension ModelContainer {
             at path: String?,
             appID: String,
             encryptionEnabled: Bool = true,
-            keyProvider: (any DatabaseKeyProvider.Type)?,
+            keyProvider: (any DatabaseKeyProvider.Type)? = nil,
             logConfiguration: LogConfiguration? = nil
         ) throws(ManagedObjectContextError) {
             try self.init(
@@ -145,7 +145,7 @@ extension ModelContainer {
             connection: Connection,
             appID: String,
             encryptionEnabled: Bool = true,
-            keyProvider: (any DatabaseKeyProvider.Type)?,
+            keyProvider: (any DatabaseKeyProvider.Type)? = nil,
             logConfiguration: LogConfiguration? = nil
         ) throws(ManagedObjectContextError) {
             try self.init(

--- a/Sources/VeinSCUI/ModelContainer.swift
+++ b/Sources/VeinSCUI/ModelContainer.swift
@@ -22,6 +22,7 @@ extension ModelContainer {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -42,24 +43,49 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    public convenience init(
-        _ versionedSchema: VersionedSchema.Type,
-        migration: SchemaMigrationPlan.Type,
-        at path: String?,
-        appID: String,
-        encryptionEnabled: Bool = true,
-        logConfiguration: LogConfiguration? = nil
-    ) throws(ManagedObjectContextError) {
-        try self.init(
-            versionedSchema,
-            migration: migration,
-            at: path,
-            appID: appID,
-            encryptionEnabled: encryptionEnabled,
-            logConfiguration: logConfiguration,
-            _notifyBeforeChange: false
-        )
-    }
+    #if !os(Android)
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            at path: String?,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)? = Vein.IntegratedKeyProvider.self,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                at: path,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #else
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            at path: String?,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)?,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                at: path,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #endif
 
     /// Manages the schema and storage for a Vein database.
     ///
@@ -70,6 +96,7 @@ extension ModelContainer {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -90,22 +117,47 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    public convenience init(
-        _ versionedSchema: VersionedSchema.Type,
-        migration: SchemaMigrationPlan.Type,
-        connection: Connection,
-        appID: String,
-        encryptionEnabled: Bool = true,
-        logConfiguration: LogConfiguration? = nil
-    ) throws(ManagedObjectContextError) {
-        try self.init(
-            versionedSchema,
-            migration: migration,
-            connection: connection,
-            appID: appID,
-            encryptionEnabled: encryptionEnabled,
-            logConfiguration: logConfiguration,
-            _notifyBeforeChange: false
-        )
-    }
+    #if !os(Android)
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            connection: Connection,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)? = Vein.IntegratedKeyProvider.self,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                connection: connection,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #else
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            connection: Connection,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)?,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                connection: connection,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: false
+            )
+        }
+    #endif
 }

--- a/Sources/VeinSCUI/ModelContainer.swift
+++ b/Sources/VeinSCUI/ModelContainer.swift
@@ -43,7 +43,7 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    #if !os(Android)
+    #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
         public convenience init(
             _ versionedSchema: VersionedSchema.Type,
             migration: SchemaMigrationPlan.Type,
@@ -117,7 +117,7 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    #if !os(Android)
+    #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
         public convenience init(
             _ versionedSchema: VersionedSchema.Type,
             migration: SchemaMigrationPlan.Type,

--- a/Sources/VeinSwiftUI/ModelContainer.swift
+++ b/Sources/VeinSwiftUI/ModelContainer.swift
@@ -71,7 +71,7 @@ extension ModelContainer {
             at path: String?,
             appID: String,
             encryptionEnabled: Bool = true,
-            keyProvider: (any DatabaseKeyProvider.Type)?,
+            keyProvider: (any DatabaseKeyProvider.Type)? = nil,
             logConfiguration: LogConfiguration? = nil
         ) throws(ManagedObjectContextError) {
             try self.init(
@@ -145,7 +145,7 @@ extension ModelContainer {
             connection: Connection,
             appID: String,
             encryptionEnabled: Bool = true,
-            keyProvider: (any DatabaseKeyProvider.Type)?,
+            keyProvider: (any DatabaseKeyProvider.Type)? = nil,
             logConfiguration: LogConfiguration? = nil
         ) throws(ManagedObjectContextError) {
             try self.init(

--- a/Sources/VeinSwiftUI/ModelContainer.swift
+++ b/Sources/VeinSwiftUI/ModelContainer.swift
@@ -22,6 +22,7 @@ extension ModelContainer {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -42,24 +43,49 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    public convenience init(
-        _ versionedSchema: VersionedSchema.Type,
-        migration: SchemaMigrationPlan.Type,
-        at path: String?,
-        appID: String,
-        encryptionEnabled: Bool = true,
-        logConfiguration: LogConfiguration? = nil
-    ) throws(ManagedObjectContextError) {
-        try self.init(
-            versionedSchema,
-            migration: migration,
-            at: path,
-            appID: appID,
-            encryptionEnabled: encryptionEnabled,
-            logConfiguration: logConfiguration,
-            _notifyBeforeChange: true
-        )
-    }
+    #if !os(Android)
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            at path: String?,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)? = Vein.IntegratedKeyProvider.self,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                at: path,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: true
+            )
+        }
+    #else
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            at path: String?,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)?,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                at: path,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: true
+            )
+        }
+    #endif
 
     /// Manages the schema and storage for a Vein database.
     ///
@@ -70,6 +96,7 @@ extension ModelContainer {
     ///   - appID: A unique identifier used per-database to construct the keyring
     ///   service string: `"com.amethyst.vein.sqlcipher.\(appID)"`.
     ///   - encryptionEnabled: Whether to apply DB-level encryption.
+    ///   - keyProvider: The structure providing and storing the database key if encryption is enabled.
     ///   - logConfiguration: What information to log.
     ///
     /// - Note: `Keyring.appIdentifier` is a global, one-time configuration for the
@@ -90,22 +117,47 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    public convenience init(
-        _ versionedSchema: VersionedSchema.Type,
-        migration: SchemaMigrationPlan.Type,
-        connection: Connection,
-        appID: String,
-        encryptionEnabled: Bool = true,
-        logConfiguration: LogConfiguration? = nil
-    ) throws(ManagedObjectContextError) {
-        try self.init(
-            versionedSchema,
-            migration: migration,
-            connection: connection,
-            appID: appID,
-            encryptionEnabled: encryptionEnabled,
-            logConfiguration: logConfiguration,
-            _notifyBeforeChange: true
-        )
-    }
+    #if !os(Android)
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            connection: Connection,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)? = Vein.IntegratedKeyProvider.self,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                connection: connection,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: true
+            )
+        }
+    #else
+        public convenience init(
+            _ versionedSchema: VersionedSchema.Type,
+            migration: SchemaMigrationPlan.Type,
+            connection: Connection,
+            appID: String,
+            encryptionEnabled: Bool = true,
+            keyProvider: (any DatabaseKeyProvider.Type)?,
+            logConfiguration: LogConfiguration? = nil
+        ) throws(ManagedObjectContextError) {
+            try self.init(
+                versionedSchema,
+                migration: migration,
+                connection: connection,
+                appID: appID,
+                encryptionEnabled: encryptionEnabled,
+                keyProvider: keyProvider,
+                logConfiguration: logConfiguration,
+                _notifyBeforeChange: true
+            )
+        }
+    #endif
 }

--- a/Sources/VeinSwiftUI/ModelContainer.swift
+++ b/Sources/VeinSwiftUI/ModelContainer.swift
@@ -43,7 +43,7 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    #if !os(Android)
+    #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
         public convenience init(
             _ versionedSchema: VersionedSchema.Type,
             migration: SchemaMigrationPlan.Type,
@@ -117,7 +117,7 @@ extension ModelContainer {
     ///     }
     /// #endif
     /// ```
-    #if !os(Android)
+    #if canImport(AppKit) || canImport(UIKit) || os(Linux) || canImport(WinSDK)
         public convenience init(
             _ versionedSchema: VersionedSchema.Type,
             migration: SchemaMigrationPlan.Type,

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -156,7 +156,7 @@ fileprivate enum Migration: SchemaMigrationPlan {
 
 #if os(Android)
     struct StubKeyProvider: DatabaseKeyProvider {
-        static var keys: [String: String]
+        static nonisolated(unsafe) var keys = [String: String]()
         static func getKey(
             fileName: String,
             service: String,

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -20,74 +20,74 @@ import Testing
     @_spi(VeinTesting) @testable import VeinCore
 #endif
 
-    @Suite
+@Suite
 struct EncryptionTest {
     func prepareContainerLocation(name: String) throws -> String {
         let containerPath = FileManager.default.temporaryDirectory
-        
+
         let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")
-        
+
         let dbPath = dbDir.appending("/\(name).sqlite3")
-        
+
         try FileManager.default.createDirectory(
             atPath: dbDir,
             withIntermediateDirectories: true
         )
-        
+
         return dbPath
     }
-    
+
     @Test
     func testEncryption() async throws {
-#if os(Linux)
-        Keyring.appIdentifier.withLock { identifier in
-            identifier = "de.amethystsoft.vein.tests"
-        }
-#endif
-        let path = try prepareContainerLocation(name: "encryptionTest")
-        
-        #if !os(Android)
-        let container = try ModelContainer(
-            V0_0_1.self,
-            migration: Migration.self,
-            at: path,
-            appID: "de.amethystsoft.vein.tests.encryption"
-        )
-        #else
-        let container = try ModelContainer(
-            V0_0_1.self,
-            migration: Migration.self,
-            at: path,
-            appID: "de.amethystsoft.vein.tests.encryption",
-            keyProvider: StubKeyProvider.self
-        )
+        #if os(Linux)
+            Keyring.appIdentifier.withLock { identifier in
+                identifier = "de.amethystsoft.vein.tests"
+            }
         #endif
-        
+        let path = try prepareContainerLocation(name: "encryptionTest")
+
+        #if !os(Android)
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: path,
+                appID: "de.amethystsoft.vein.tests.encryption"
+            )
+        #else
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: path,
+                appID: "de.amethystsoft.vein.tests.encryption",
+                keyProvider: StubKeyProvider.self
+            )
+        #endif
+
         let model = V0_0_1.Test(someValue: "test")
         try container.context.insert(model)
         try container.context.save()
-        
-#if !os(Android)
-        let newContainer = try ModelContainer(
-            V0_0_1.self,
-            migration: Migration.self,
-            at: path,
-            appID: "de.amethystsoft.vein.tests.encryption"
-        )
+
+        #if !os(Android)
+            let newContainer = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: path,
+                appID: "de.amethystsoft.vein.tests.encryption"
+            )
         #else
-        let newContainer = try ModelContainer(
-            V0_0_1.self,
-            migration: Migration.self,
-            at: path,
-            appID: "de.amethystsoft.vein.tests.encryption",
-            keyProvider: StubKeyProvider.self
-        )
+            let newContainer = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: path,
+                appID: "de.amethystsoft.vein.tests.encryption",
+                keyProvider: StubKeyProvider.self
+            )
         #endif
-        
+
         let first = try newContainer.context.fetchAll(V0_0_1.Test.self).first
-        
+
         #expect(first?.someValue == "test")
-        
+
         do {
             let unencryptedContainer = try ModelContainer(
                 V0_0_1.self,
@@ -96,7 +96,7 @@ struct EncryptionTest {
                 appID: "de.amethystsoft.vein.tests.encryption",
                 encryptionEnabled: false
             )
-            
+
             _ = try unencryptedContainer.context.fetchAll(V0_0_1.Test.self)
             Issue.record("Didn't throw an error, db might not be encrypted")
         } catch {
@@ -105,37 +105,38 @@ struct EncryptionTest {
             return
         }
     }
-    
+
     #if os(Android)
-    @Test
-    func encryptionEnabledDBWithoutKeyProviderThrows() async throws {
-        do {
-            try ModelContainer(
-                V0_0_1.self,
-                migration: Migration.self,
-                at: path,
-                appID: "de.amethystsoft.vein.tests.encryption"
-            )
-        } catch {
-            #expect(error == .other(message: "Failed to retrieve/save key to encrypt Database."))
-            return
+        @Test
+        func encryptionEnabledDBWithoutKeyProviderThrows() async throws {
+            do {
+                try ModelContainer(
+                    V0_0_1.self,
+                    migration: Migration.self,
+                    at: path,
+                    appID: "de.amethystsoft.vein.tests.encryption"
+                )
+            } catch {
+                #expect(error ==
+                    .other(message: "Failed to retrieve/save key to encrypt Database."))
+                return
+            }
+            Issue.record("Unexpectedly didn't throw.")
         }
-        Issue.record("Unexpectedly didn't throw.")
-    }
     #endif
 }
 
 fileprivate enum V0_0_1: VersionedSchema {
     static let version = ModelVersion(0, 0, 1)
     static let models: [any Vein.PersistentModel.Type] = [Test.self]
-    
+
     @Model
     final class Test: Identifiable {
         var someValue: String
-        
+
         @LazyField
         var text: String?
-        
+
         init(someValue: String) {
             self.someValue = someValue
         }
@@ -146,32 +147,32 @@ fileprivate enum Migration: SchemaMigrationPlan {
     static var schemas: [any Vein.VersionedSchema.Type] {
         [V0_0_1.self]
     }
-    
+
     static var stages: [MigrationStage] {
         []
     }
 }
 
 #if os(Android)
-struct StubKeyProvider: DatabaseKeyProvider {
-    static var keys: [String: String]
-    static func getKey(
-        fileName: String,
-        service: String,
-        generate: (() -> String)?
-    ) throws(KeyProviderError) -> String {
-        let ressource = "\(service)+\(fileName)"
-        
-        if let key = Self.keys[ressource] {
-            return key
-        } else if let generate {
-            let key = generate()
-            
-            Self.keys[ressource] = key
-            return key
+    struct StubKeyProvider: DatabaseKeyProvider {
+        static var keys: [String: String]
+        static func getKey(
+            fileName: String,
+            service: String,
+            generate: (() -> String)?
+        ) throws(KeyProviderError) -> String {
+            let ressource = "\(service)+\(fileName)"
+
+            if let key = Self.keys[ressource] {
+                return key
+            } else if let generate {
+                let key = generate()
+
+                Self.keys[ressource] = key
+                return key
+            }
+
+            throw .noSuchKey
         }
-        
-        throw .noSuchKey
     }
-}
 #endif

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -118,10 +118,9 @@ struct EncryptionTest {
                     appID: "de.amethystsoft.vein.tests.encryption"
                 )
             } catch let error as ManagedObjectContextError {
-                #expect(error.localizedDescription ==
-                    ManagedObjectContextError
-                    .other(message: "Failed to retrieve/save key to encrypt Database.")
-                    .localizedDescription)
+                #expect(error.localizedDescription
+                    .hasSuffix("Failed to retrieve/save key to encrypt Database.")
+                )
                 return
             }
             Issue.record("Unexpectedly didn't throw.")

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -111,7 +111,7 @@ struct EncryptionTest {
         func encryptionEnabledDBWithoutKeyProviderThrows() async throws {
             let path = try prepareContainerLocation(name: "androidEncryptionTest")
             do {
-                try ModelContainer(
+                _ = try ModelContainer(
                     V0_0_1.self,
                     migration: Migration.self,
                     at: path,

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -109,6 +109,7 @@ struct EncryptionTest {
     #if os(Android)
         @Test
         func encryptionEnabledDBWithoutKeyProviderThrows() async throws {
+            let path = try prepareContainerLocation(name: "androidEncryptionTest")
             do {
                 try ModelContainer(
                     V0_0_1.self,
@@ -116,7 +117,7 @@ struct EncryptionTest {
                     at: path,
                     appID: "de.amethystsoft.vein.tests.encryption"
                 )
-            } catch {
+            } catch let error as ManagedObjectContextError {
                 #expect(error ==
                     ManagedObjectContextError
                     .other(message: "Failed to retrieve/save key to encrypt Database."))

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -118,7 +118,7 @@ struct EncryptionTest {
                 )
             } catch {
                 #expect(error ==
-                    .other(message: "Failed to retrieve/save key to encrypt Database."))
+                    ManagedObjectContextError.other(message: "Failed to retrieve/save key to encrypt Database."))
                 return
             }
             Issue.record("Unexpectedly didn't throw.")

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -118,6 +118,7 @@ struct EncryptionTest {
                 )
             } catch {
                 #expect(error ==
+                    ManagedObjectContextError
                     .other(message: "Failed to retrieve/save key to encrypt Database."))
                 return
             }

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -20,98 +20,158 @@ import Testing
     @_spi(VeinTesting) @testable import VeinCore
 #endif
 
-#if !os(Android)
     @Suite
-    struct EncryptionTest {
-        func prepareContainerLocation(name: String) throws -> String {
-            let containerPath = FileManager.default.temporaryDirectory
-
-            let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")
-
-            let dbPath = dbDir.appending("/\(name).sqlite3")
-
-            try FileManager.default.createDirectory(
-                atPath: dbDir,
-                withIntermediateDirectories: true
-            )
-
-            return dbPath
+struct EncryptionTest {
+    func prepareContainerLocation(name: String) throws -> String {
+        let containerPath = FileManager.default.temporaryDirectory
+        
+        let dbDir = containerPath.relativePath.appending("/veinTests/\(testID.uuidString)")
+        
+        let dbPath = dbDir.appending("/\(name).sqlite3")
+        
+        try FileManager.default.createDirectory(
+            atPath: dbDir,
+            withIntermediateDirectories: true
+        )
+        
+        return dbPath
+    }
+    
+    @Test
+    func testEncryption() async throws {
+#if os(Linux)
+        Keyring.appIdentifier.withLock { identifier in
+            identifier = "de.amethystsoft.vein.tests"
         }
-
-        @Test
-        func testEncryption() async throws {
-            #if os(Linux)
-                Keyring.appIdentifier.withLock { identifier in
-                    identifier = "de.amethystsoft.vein.tests"
-                }
-            #endif
-            let path = try prepareContainerLocation(name: "encryptionTest")
-
-            let container = try ModelContainer(
+#endif
+        let path = try prepareContainerLocation(name: "encryptionTest")
+        
+        #if !os(Android)
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: path,
+            appID: "de.amethystsoft.vein.tests.encryption"
+        )
+        #else
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: path,
+            appID: "de.amethystsoft.vein.tests.encryption",
+            keyProvider: StubKeyProvider.self
+        )
+        #endif
+        
+        let model = V0_0_1.Test(someValue: "test")
+        try container.context.insert(model)
+        try container.context.save()
+        
+#if !os(Android)
+        let newContainer = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: path,
+            appID: "de.amethystsoft.vein.tests.encryption"
+        )
+        #else
+        let newContainer = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: path,
+            appID: "de.amethystsoft.vein.tests.encryption",
+            keyProvider: StubKeyProvider.self
+        )
+        #endif
+        
+        let first = try newContainer.context.fetchAll(V0_0_1.Test.self).first
+        
+        #expect(first?.someValue == "test")
+        
+        do {
+            let unencryptedContainer = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: path,
+                appID: "de.amethystsoft.vein.tests.encryption",
+                encryptionEnabled: false
+            )
+            
+            _ = try unencryptedContainer.context.fetchAll(V0_0_1.Test.self)
+            Issue.record("Didn't throw an error, db might not be encrypted")
+        } catch {
+            if case .notADatabase = error { return }
+            Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
+            return
+        }
+    }
+    
+    #if os(Android)
+    @Test
+    func encryptionEnabledDBWithoutKeyProviderThrows() async throws {
+        do {
+            try ModelContainer(
                 V0_0_1.self,
                 migration: Migration.self,
                 at: path,
                 appID: "de.amethystsoft.vein.tests.encryption"
             )
+        } catch {
+            #expect(error == .other(message: "Failed to retrieve/save key to encrypt Database."))
+            return
+        }
+        Issue.record("Unexpectedly didn't throw.")
+    }
+    #endif
+}
 
-            let model = V0_0_1.Test(someValue: "test")
-            try container.context.insert(model)
-            try container.context.save()
-
-            let newContainer = try ModelContainer(
-                V0_0_1.self,
-                migration: Migration.self,
-                at: path,
-                appID: "de.amethystsoft.vein.tests.encryption"
-            )
-
-            let first = try newContainer.context.fetchAll(V0_0_1.Test.self).first
-
-            #expect(first?.someValue == "test")
-
-            do {
-                let unencryptedContainer = try ModelContainer(
-                    V0_0_1.self,
-                    migration: Migration.self,
-                    at: path,
-                    appID: "de.amethystsoft.vein.tests.encryption",
-                    encryptionEnabled: false
-                )
-
-                _ = try unencryptedContainer.context.fetchAll(V0_0_1.Test.self)
-                Issue.record("Didn't throw an error, db might not be encrypted")
-            } catch {
-                if case .notADatabase = error { return }
-                Issue.record("Thrown error does not match expectations: \(error.errorDescription)")
-                return
-            }
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self]
+    
+    @Model
+    final class Test: Identifiable {
+        var someValue: String
+        
+        @LazyField
+        var text: String?
+        
+        init(someValue: String) {
+            self.someValue = someValue
         }
     }
+}
 
-    fileprivate enum V0_0_1: VersionedSchema {
-        static let version = ModelVersion(0, 0, 1)
-        static let models: [any Vein.PersistentModel.Type] = [Test.self]
-
-        @Model
-        final class Test: Identifiable {
-            var someValue: String
-
-            @LazyField
-            var text: String?
-
-            init(someValue: String) {
-                self.someValue = someValue
-            }
-        }
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
     }
-
-    fileprivate enum Migration: SchemaMigrationPlan {
-        static var schemas: [any Vein.VersionedSchema.Type] {
-            [V0_0_1.self]
-        }
-
-        static var stages: [MigrationStage] {
-            []
-        }
+    
+    static var stages: [MigrationStage] {
+        []
     }
+}
+
+#if os(Android)
+struct StubKeyProvider: DatabaseKeyProvider {
+    static var keys: [String: String]
+    static func getKey(
+        fileName: String,
+        service: String,
+        generate: (() -> String)?
+    ) throws(KeyProviderError) -> String {
+        let ressource = "\(service)+\(fileName)"
+        
+        if let key = Self.keys[ressource] {
+            return key
+        } else if let generate {
+            let key = generate()
+            
+            Self.keys[ressource] = key
+            return key
+        }
+        
+        throw .noSuchKey
+    }
+}
 #endif

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -118,9 +118,9 @@ struct EncryptionTest {
                     appID: "de.amethystsoft.vein.tests.encryption"
                 )
             } catch let error as ManagedObjectContextError {
-                #expect(error ==
+                #expect(error.localizedDescription ==
                     ManagedObjectContextError
-                    .other(message: "Failed to retrieve/save key to encrypt Database."))
+                    .other(message: "Failed to retrieve/save key to encrypt Database.").localizedDescription)
                 return
             }
             Issue.record("Unexpectedly didn't throw.")

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -78,7 +78,7 @@ import Testing
                     encryptionEnabled: false
                 )
 
-                let results = try unencryptedContainer.context.fetchAll(V0_0_1.Test.self)
+                _ = try unencryptedContainer.context.fetchAll(V0_0_1.Test.self)
                 Issue.record("Didn't throw an error, db might not be encrypted")
             } catch {
                 if case .notADatabase = error { return }

--- a/Tests/VeinTests/Encryption/EncryptionTest.swift
+++ b/Tests/VeinTests/Encryption/EncryptionTest.swift
@@ -120,7 +120,8 @@ struct EncryptionTest {
             } catch let error as ManagedObjectContextError {
                 #expect(error.localizedDescription ==
                     ManagedObjectContextError
-                    .other(message: "Failed to retrieve/save key to encrypt Database.").localizedDescription)
+                    .other(message: "Failed to retrieve/save key to encrypt Database.")
+                    .localizedDescription)
                 return
             }
             Issue.record("Unexpectedly didn't throw.")

--- a/Tests/VeinTests/Persistable/RawRepresentable.swift
+++ b/Tests/VeinTests/Persistable/RawRepresentable.swift
@@ -56,6 +56,8 @@ struct PersistableTests {
             appID: "de.amethystsoft.vein.tests.persistable",
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
+        
+        try runUpdate()
 
         guard
             let model = try container.context.fetchAll(V0_0_1.Account.self).first
@@ -79,6 +81,7 @@ struct PersistableTests {
                 let model = try updateContainer.context.fetchAll(V0_0_1.Account.self).first
             else {
                 Issue.record("Unexpectedly found no model.")
+                return
             }
 
             #expect(model.accountType == .admin)

--- a/Tests/VeinTests/Persistable/RawRepresentable.swift
+++ b/Tests/VeinTests/Persistable/RawRepresentable.swift
@@ -48,7 +48,6 @@ struct PersistableTests {
     @Test
     func testRawRepresentablePersistableUpdate() async throws {
         let connection = try setupContainer()
-        let newObjectID = try runUpdate()
 
         let container = try ModelContainer(
             V0_0_1.self,
@@ -67,7 +66,7 @@ struct PersistableTests {
 
         #expect(model.accountType == .user)
 
-        func runUpdate() throws -> ObjectIdentifier? {
+        func runUpdate() throws {
             let updateContainer = try ModelContainer(
                 V0_0_1.self,
                 migration: Migration.self,
@@ -80,7 +79,6 @@ struct PersistableTests {
                 let model = try updateContainer.context.fetchAll(V0_0_1.Account.self).first
             else {
                 Issue.record("Unexpectedly found no model.")
-                return nil
             }
 
             #expect(model.accountType == .admin)
@@ -90,8 +88,6 @@ struct PersistableTests {
             #expect(updateContainer.context.hasChanges)
 
             try updateContainer.context.save()
-
-            return ObjectIdentifier(model)
         }
     }
 

--- a/Tests/VeinTests/Persistable/RawRepresentable.swift
+++ b/Tests/VeinTests/Persistable/RawRepresentable.swift
@@ -56,7 +56,7 @@ struct PersistableTests {
             appID: "de.amethystsoft.vein.tests.persistable",
             encryptionEnabled: ProcessInfo.shouldEnableEncryption
         )
-        
+
         try runUpdate()
 
         guard


### PR DESCRIPTION
resolves #97 

Adds a `DatabaseKeyProvider` protocol and moves the current key logic to separate implementations of said protocol.

Each integrated provider is set on a typealias `IntegratedKeyProvider` on each platform, excluding android.

Also added a test for android using a stub provider.

Sideeffects:
- moved windows CI off of Blacksmith cause it ate too many credits
- fixed some compiler warnings in the main project
- removed dependency on swift-crypto, now uses Foundation.RandomNumberGenerator