### PR TITLE
Improve publish to enclosing observer chain

### DIFF
--- a/Sources/VeinSCUI/Query.swift
+++ b/Sources/VeinSCUI/Query.swift
@@ -67,14 +67,15 @@
     }
 
     package final class QueryObserver<M: PersistentModel>: @unchecked Sendable {
+        var id = UUID()
         var didChange = Publisher()
         static var logger: Logger { Logger(label: "Vein.QueryObserver<\(M.self)>") }
 
         typealias ModelType = M
 
-        private var publishToEnclosingObserver: (() -> Void)?
+        private var enclosingObservers = [UUID: () -> Void]()
 
-        fileprivate var primaryObserver: QueryObserver<M>?
+        var primaryObserver: QueryObserver<M>?
 
         let predicate: ModelPredicate<M>
 
@@ -101,9 +102,7 @@
 
             if primary !== self {
                 self.primaryObserver = primary
-                let old = primary.publishToEnclosingObserver
-                primary.publishToEnclosingObserver = { [weak self] in
-                    old?()
+                primary.enclosingObservers[id] = { [weak self] in
                     self?.didChange.send()
                 }
             } else {
@@ -135,7 +134,7 @@
             // there is only one Query instance kept in the context for the same filter.
             // this triggers view updates on any other Query oberservers using the registered
             // Query as their source
-            publishToEnclosingObserver?()
+            publishToEnclosingObserver()
             didChange.send()
         }
 
@@ -164,7 +163,7 @@
                 results?.removeAll(where: { $0.id == model.id })
             }
 
-            publishToEnclosingObserver?()
+            publishToEnclosingObserver()
             didChange.send()
         }
 
@@ -179,8 +178,19 @@
             guard let model = model as? ModelType else { return }
             results?.removeAll(where: { $0.id == model.id })
 
-            publishToEnclosingObserver?()
+            publishToEnclosingObserver()
             didChange.send()
+        }
+        
+        func publishToEnclosingObserver() {
+            for publish in enclosingObservers.values {
+                publish()
+            }
+        }
+        
+        deinit {
+            guard let primaryObserver else { return }
+            primaryObserver.enclosingObservers[id] = nil
         }
     }
 

--- a/Sources/VeinSCUI/Query.swift
+++ b/Sources/VeinSCUI/Query.swift
@@ -183,14 +183,14 @@
             publishToEnclosingObserver()
             didChange.send()
         }
-        
+
         func publishToEnclosingObserver() {
             let observers = enclosingObservers.mutate { $0.values }
             for publish in observers {
                 publish()
             }
         }
-        
+
         deinit {
             guard let primaryObserver else { return }
             primaryObserver.enclosingObservers.mutate { observers in

--- a/Sources/VeinSCUI/Query.swift
+++ b/Sources/VeinSCUI/Query.swift
@@ -73,7 +73,7 @@
 
         typealias ModelType = M
 
-        private var enclosingObservers = [UUID: () -> Void]()
+        private let enclosingObservers = Mutex([UUID: () -> Void]())
 
         var primaryObserver: QueryObserver<M>?
 
@@ -102,8 +102,10 @@
 
             if primary !== self {
                 self.primaryObserver = primary
-                primary.enclosingObservers[id] = { [weak self] in
-                    self?.didChange.send()
+                primary.enclosingObservers.mutate { observers in
+                    observers[id] = { [weak self] in
+                        self?.didChange.send()
+                    }
                 }
             } else {
                 fetchInitialResults(with: context)
@@ -183,14 +185,17 @@
         }
         
         func publishToEnclosingObserver() {
-            for publish in enclosingObservers.values {
+            let observers = enclosingObservers.mutate { $0.values }
+            for publish in observers {
                 publish()
             }
         }
         
         deinit {
             guard let primaryObserver else { return }
-            primaryObserver.enclosingObservers[id] = nil
+            primaryObserver.enclosingObservers.mutate { observers in
+                observers[id] = nil
+            }
         }
     }
 

--- a/Sources/VeinSwiftUI/Query.swift
+++ b/Sources/VeinSwiftUI/Query.swift
@@ -165,14 +165,14 @@
             objectWillChange.send()
             results?.removeAll(where: { $0.id == model.id })
         }
-        
+
         func publishToEnclosingObserver() {
             let observers = enclosingObservers.mutate { $0.values }
             for publish in observers {
                 publish()
             }
         }
-        
+
         deinit {
             guard let primaryObserver else { return }
             primaryObserver.enclosingObservers.mutate { observers in

--- a/Sources/VeinSwiftUI/Query.swift
+++ b/Sources/VeinSwiftUI/Query.swift
@@ -56,7 +56,7 @@
         public let objectWillChange = PassthroughSubject<Void, Never>()
         static var logger: Logger { Logger(label: "Vein.QueryObserver<\(M.self)>") }
 
-        private var enclosingObservers = [UUID: () -> Void]()
+        private let enclosingObservers = Mutex([UUID: () -> Void]())
 
         var primaryObserver: QueryObserver<M>?
 
@@ -85,8 +85,10 @@
 
             if primary !== self {
                 self.primaryObserver = primary
-                primary.enclosingObservers[id] = { [weak self] in
-                    self?.objectWillChange.send()
+                primary.enclosingObservers.mutate { observers in
+                    observers[id] = { [weak self] in
+                        self?.objectWillChange.send()
+                    }
                 }
             } else {
                 fetchInitialResults(with: context)
@@ -165,14 +167,17 @@
         }
         
         func publishToEnclosingObserver() {
-            for publish in enclosingObservers.values {
+            let observers = enclosingObservers.mutate { $0.values }
+            for publish in observers {
                 publish()
             }
         }
         
         deinit {
             guard let primaryObserver else { return }
-            primaryObserver.enclosingObservers[id] = nil
+            primaryObserver.enclosingObservers.mutate { observers in
+                observers[id] = nil
+            }
         }
     }
 

--- a/Sources/VeinSwiftUI/Query.swift
+++ b/Sources/VeinSwiftUI/Query.swift
@@ -51,13 +51,14 @@
     }
 
     package final class QueryObserver<M: PersistentModel>: ObservableObject, @unchecked Sendable {
+        var id = UUID()
         typealias ModelType = M
         public let objectWillChange = PassthroughSubject<Void, Never>()
         static var logger: Logger { Logger(label: "Vein.QueryObserver<\(M.self)>") }
 
-        private var publishToEnclosingObserver: (() -> Void)?
+        private var enclosingObservers = [UUID: () -> Void]()
 
-        fileprivate var primaryObserver: QueryObserver<M>?
+        var primaryObserver: QueryObserver<M>?
 
         let predicate: ModelPredicate<M>
 
@@ -84,9 +85,7 @@
 
             if primary !== self {
                 self.primaryObserver = primary
-                let old = primary.publishToEnclosingObserver
-                primary.publishToEnclosingObserver = { [weak self] in
-                    old?()
+                primary.enclosingObservers[id] = { [weak self] in
                     self?.objectWillChange.send()
                 }
             } else {
@@ -115,7 +114,7 @@
             // there is only one Query instance kept in the context for the same filter.
             // this triggers view updates on any other Query oberservers using the registered
             // Query as their source
-            publishToEnclosingObserver?()
+            publishToEnclosingObserver()
             objectWillChange.send()
             results?.append(contentsOf: models.filter {
                 return predicate.runtimeFilter($0)
@@ -139,7 +138,7 @@
             let matchesNow = predicate.runtimeFilter(model)
             guard matchesNow || matchedBeforeChange else { return }
 
-            publishToEnclosingObserver?()
+            publishToEnclosingObserver()
             objectWillChange.send()
 
             if matchesNow {
@@ -160,9 +159,20 @@
         @MainActor
         package func remove(_ model: any PersistentModel) {
             guard let model = model as? ModelType else { return }
-            publishToEnclosingObserver?()
+            publishToEnclosingObserver()
             objectWillChange.send()
             results?.removeAll(where: { $0.id == model.id })
+        }
+        
+        func publishToEnclosingObserver() {
+            for publish in enclosingObservers.values {
+                publish()
+            }
+        }
+        
+        deinit {
+            guard let primaryObserver else { return }
+            primaryObserver.enclosingObservers[id] = nil
         }
     }
 

--- a/Tests/VeinTests/VeinSCUI/SCUIQueryObserverChain.swift
+++ b/Tests/VeinTests/VeinSCUI/SCUIQueryObserverChain.swift
@@ -1,0 +1,96 @@
+#if TEST_SCUI
+import Foundation
+@testable import VeinSCUI
+import SwiftCrossUI
+import Testing
+
+@Suite @MainActor
+struct QueryObserverChain {
+    @Test(.timeLimit(.minutes(1)))
+    func publishingWorks() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.test.scuiqueryobserver"
+        )
+        
+        let query = Query(#Predicate<V0_0_1.Test>{ model in
+            model.flag == true
+        })
+        
+        let query2 = Query(#Predicate<V0_0_1.Test>{ model in
+            model.flag == true
+        })
+        
+        let query3 = Query(#Predicate<V0_0_1.Test>{ model in
+            model.flag == true
+        })
+        
+        query.context = container.context
+        query2.context = container.context
+        query3.context = container.context
+        
+        /// Only on first access does a query register on the context
+        _ = query.wrappedValue
+        _ = query2.wrappedValue
+        _ = query3.wrappedValue
+        
+        guard
+            let primaryOf2 = query2.queryObserver.primaryObserver,
+            let primaryOf3 = query3.queryObserver.primaryObserver
+        else {
+            Issue.record("""
+                Query 2 and 3 should have primary observers as as they are created \
+                after the first one.
+            """)
+            return
+        }
+        
+        #expect(ObjectIdentifier(query.queryObserver) == ObjectIdentifier(primaryOf2))
+        #expect(ObjectIdentifier(query.queryObserver) == ObjectIdentifier(primaryOf3))
+        
+        await confirmation(
+            "Confirm didChange was signaled",
+            expectedCount: 2
+        ) { confirmed in
+            let cancellable = query2.didChange.observe {
+                confirmed()
+            }
+            let cancellable2 = query3.didChange.observe {
+                confirmed()
+            }
+            
+            query.queryObserver.publishToEnclosingObserver()
+            
+            _ = cancellable
+            _ = cancellable2
+        }
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self]
+    
+    @Model
+    final class Test: Identifiable {
+        @Field
+        var flag: Bool
+        
+        init(flag: Bool) {
+            self.flag = flag
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}
+#endif

--- a/Tests/VeinTests/VeinSCUI/SCUIQueryObserverChain.swift
+++ b/Tests/VeinTests/VeinSCUI/SCUIQueryObserverChain.swift
@@ -1,96 +1,108 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
 #if TEST_SCUI
-import Foundation
-@testable import VeinSCUI
-import SwiftCrossUI
-import Testing
+    import Foundation
+    @testable import VeinSCUI
+    import SwiftCrossUI
+    import Testing
 
-@Suite @MainActor
-struct QueryObserverChain {
-    @Test(.timeLimit(.minutes(1)))
-    func publishingWorks() async throws {
-        let container = try ModelContainer(
-            V0_0_1.self,
-            migration: Migration.self,
-            at: nil,
-            appID: "de.amethystsoft.vein.test.scuiqueryobserver"
-        )
-        
-        let query = Query(#Predicate<V0_0_1.Test>{ model in
-            model.flag == true
-        })
-        
-        let query2 = Query(#Predicate<V0_0_1.Test>{ model in
-            model.flag == true
-        })
-        
-        let query3 = Query(#Predicate<V0_0_1.Test>{ model in
-            model.flag == true
-        })
-        
-        query.context = container.context
-        query2.context = container.context
-        query3.context = container.context
-        
-        /// Only on first access does a query register on the context
-        _ = query.wrappedValue
-        _ = query2.wrappedValue
-        _ = query3.wrappedValue
-        
-        guard
-            let primaryOf2 = query2.queryObserver.primaryObserver,
-            let primaryOf3 = query3.queryObserver.primaryObserver
-        else {
-            Issue.record("""
-                Query 2 and 3 should have primary observers as as they are created \
-                after the first one.
-            """)
-            return
-        }
-        
-        #expect(ObjectIdentifier(query.queryObserver) == ObjectIdentifier(primaryOf2))
-        #expect(ObjectIdentifier(query.queryObserver) == ObjectIdentifier(primaryOf3))
-        
-        await confirmation(
-            "Confirm didChange was signaled",
-            expectedCount: 2
-        ) { confirmed in
-            let cancellable = query2.didChange.observe {
-                confirmed()
+    @Suite @MainActor
+    struct QueryObserverChain {
+        @Test(.timeLimit(.minutes(1)))
+        func publishingWorks() async throws {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.test.scuiqueryobserver"
+            )
+
+            let query = Query(#Predicate<V0_0_1.Test>{ model in
+                model.flag == true
+            })
+
+            let query2 = Query(#Predicate<V0_0_1.Test>{ model in
+                model.flag == true
+            })
+
+            let query3 = Query(#Predicate<V0_0_1.Test>{ model in
+                model.flag == true
+            })
+
+            query.context = container.context
+            query2.context = container.context
+            query3.context = container.context
+
+            /// Only on first access does a query register on the context
+            _ = query.wrappedValue
+            _ = query2.wrappedValue
+            _ = query3.wrappedValue
+
+            guard
+                let primaryOf2 = query2.queryObserver.primaryObserver,
+                let primaryOf3 = query3.queryObserver.primaryObserver
+            else {
+                Issue.record("""
+                        Query 2 and 3 should have primary observers as as they are created \
+                        after the first one.
+                    """)
+                return
             }
-            let cancellable2 = query3.didChange.observe {
-                confirmed()
+
+            #expect(ObjectIdentifier(query.queryObserver) == ObjectIdentifier(primaryOf2))
+            #expect(ObjectIdentifier(query.queryObserver) == ObjectIdentifier(primaryOf3))
+
+            await confirmation(
+                "Confirm didChange was signaled",
+                expectedCount: 2
+            ) { confirmed in
+                let cancellable = query2.didChange.observe {
+                    confirmed()
+                }
+                let cancellable2 = query3.didChange.observe {
+                    confirmed()
+                }
+
+                query.queryObserver.publishToEnclosingObserver()
+
+                _ = cancellable
+                _ = cancellable2
             }
-            
-            query.queryObserver.publishToEnclosingObserver()
-            
-            _ = cancellable
-            _ = cancellable2
         }
     }
-}
 
-fileprivate enum V0_0_1: VersionedSchema {
-    static let version = ModelVersion(0, 0, 1)
-    static let models: [any Vein.PersistentModel.Type] = [Test.self]
-    
-    @Model
-    final class Test: Identifiable {
-        @Field
-        var flag: Bool
-        
-        init(flag: Bool) {
-            self.flag = flag
+    fileprivate enum V0_0_1: VersionedSchema {
+        static let version = ModelVersion(0, 0, 1)
+        static let models: [any Vein.PersistentModel.Type] = [Test.self]
+
+        @Model
+        final class Test: Identifiable {
+            @Field
+            var flag: Bool
+
+            init(flag: Bool) {
+                self.flag = flag
+            }
         }
     }
-}
 
-fileprivate enum Migration: SchemaMigrationPlan {
-    static var schemas: [any Vein.VersionedSchema.Type] {
-        [V0_0_1.self]
+    fileprivate enum Migration: SchemaMigrationPlan {
+        static var schemas: [any Vein.VersionedSchema.Type] {
+            [V0_0_1.self]
+        }
+
+        static var stages: [MigrationStage] {
+            []
+        }
     }
-    
-    static var stages: [MigrationStage] {
-        []
-    }
-}
 #endif

--- a/Tests/VeinTests/VeinSwiftUI/SwiftUIQueryObserverChain.swift
+++ b/Tests/VeinTests/VeinSwiftUI/SwiftUIQueryObserverChain.swift
@@ -1,92 +1,104 @@
+// ===----------------------------------------------------------------------===
+//
+// This source file is part of the Amethyst Vein open source project
+//
+// Copyright (c) 2026 Mia Koring.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ===----------------------------------------------------------------------===
+
 #if TEST_SWIFTUI
-import Foundation
-@testable import VeinSwiftUI
-@testable import Vein
-import Testing
+    import Foundation
+    @testable import VeinSwiftUI
+    @testable import Vein
+    import Testing
 
-@Suite @MainActor
-struct QueryObserverChain {
-    @Test(.timeLimit(.minutes(1)))
-    func publishingWorks() async throws {
-        let container = try ModelContainer(
-            V0_0_1.self,
-            migration: Migration.self,
-            at: nil,
-            appID: "de.amethystsoft.vein.test.scuiqueryobserver"
-        )
-        
-        let query = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
-            model.flag == true
-        }))
-        
-        let query2 = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
-            model.flag == true
-        }))
-        
-        let query3 = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
-            model.flag == true
-        }))
-        
-        query.initialize(with: container.context)
-        query2.initialize(with: container.context)
-        query3.initialize(with: container.context)
-        
-        guard
-            let primaryOf2 = query2.primaryObserver,
-            let primaryOf3 = query3.primaryObserver
-                else {
-            Issue.record("""
-                Query 2 and 3 should have primary observers as as they are created \
-                after the first one. 2: \(query2.primaryObserver) \
-                3: \(query3.primaryObserver)
-            """)
-            return
-        }
-        
-        #expect(ObjectIdentifier(query) == ObjectIdentifier(primaryOf2))
-        #expect(ObjectIdentifier(query) == ObjectIdentifier(primaryOf3))
-        
-        await confirmation(
-            "Confirm didChange was signaled",
-            expectedCount: 2
-        ) { confirmed in
-            let cancellable = query2.objectWillChange.sink {
-                confirmed()
+    @Suite @MainActor
+    struct QueryObserverChain {
+        @Test(.timeLimit(.minutes(1)))
+        func publishingWorks() async throws {
+            let container = try ModelContainer(
+                V0_0_1.self,
+                migration: Migration.self,
+                at: nil,
+                appID: "de.amethystsoft.vein.test.scuiqueryobserver"
+            )
+
+            let query = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
+                model.flag == true
+            }))
+
+            let query2 = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
+                model.flag == true
+            }))
+
+            let query3 = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
+                model.flag == true
+            }))
+
+            query.initialize(with: container.context)
+            query2.initialize(with: container.context)
+            query3.initialize(with: container.context)
+
+            guard
+                let primaryOf2 = query2.primaryObserver,
+                let primaryOf3 = query3.primaryObserver
+            else {
+                Issue.record("""
+                        Query 2 and 3 should have primary observers as as they are created \
+                        after the first one. 2: \(query2.primaryObserver) \
+                        3: \(query3.primaryObserver)
+                    """)
+                return
             }
-            let cancellable2 = query3.objectWillChange.sink {
-                confirmed()
+
+            #expect(ObjectIdentifier(query) == ObjectIdentifier(primaryOf2))
+            #expect(ObjectIdentifier(query) == ObjectIdentifier(primaryOf3))
+
+            await confirmation(
+                "Confirm didChange was signaled",
+                expectedCount: 2
+            ) { confirmed in
+                let cancellable = query2.objectWillChange.sink {
+                    confirmed()
+                }
+                let cancellable2 = query3.objectWillChange.sink {
+                    confirmed()
+                }
+
+                query.publishToEnclosingObserver()
+
+                _ = cancellable
+                _ = cancellable2
             }
-            
-            query.publishToEnclosingObserver()
-            
-            _ = cancellable
-            _ = cancellable2
         }
     }
-}
 
-fileprivate enum V0_0_1: VersionedSchema {
-    static let version = ModelVersion(0, 0, 1)
-    static let models: [any Vein.PersistentModel.Type] = [Test.self]
-    
-    @Model
-    final class Test: Identifiable {
-        @Field
-        var flag: Bool
-        
-        init(flag: Bool) {
-            self.flag = flag
+    fileprivate enum V0_0_1: VersionedSchema {
+        static let version = ModelVersion(0, 0, 1)
+        static let models: [any Vein.PersistentModel.Type] = [Test.self]
+
+        @Model
+        final class Test: Identifiable {
+            @Field
+            var flag: Bool
+
+            init(flag: Bool) {
+                self.flag = flag
+            }
         }
     }
-}
 
-fileprivate enum Migration: SchemaMigrationPlan {
-    static var schemas: [any Vein.VersionedSchema.Type] {
-        [V0_0_1.self]
+    fileprivate enum Migration: SchemaMigrationPlan {
+        static var schemas: [any Vein.VersionedSchema.Type] {
+            [V0_0_1.self]
+        }
+
+        static var stages: [MigrationStage] {
+            []
+        }
     }
-    
-    static var stages: [MigrationStage] {
-        []
-    }
-}
 #endif

--- a/Tests/VeinTests/VeinSwiftUI/SwiftUIQueryObserverChain.swift
+++ b/Tests/VeinTests/VeinSwiftUI/SwiftUIQueryObserverChain.swift
@@ -1,0 +1,92 @@
+#if TEST_SWIFTUI
+import Foundation
+@testable import VeinSwiftUI
+@testable import Vein
+import Testing
+
+@Suite @MainActor
+struct QueryObserverChain {
+    @Test(.timeLimit(.minutes(1)))
+    func publishingWorks() async throws {
+        let container = try ModelContainer(
+            V0_0_1.self,
+            migration: Migration.self,
+            at: nil,
+            appID: "de.amethystsoft.vein.test.scuiqueryobserver"
+        )
+        
+        let query = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
+            model.flag == true
+        }))
+        
+        let query2 = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
+            model.flag == true
+        }))
+        
+        let query3 = try QueryObserver(ModelPredicate(#Predicate<V0_0_1.Test>{ model in
+            model.flag == true
+        }))
+        
+        query.initialize(with: container.context)
+        query2.initialize(with: container.context)
+        query3.initialize(with: container.context)
+        
+        guard
+            let primaryOf2 = query2.primaryObserver,
+            let primaryOf3 = query3.primaryObserver
+                else {
+            Issue.record("""
+                Query 2 and 3 should have primary observers as as they are created \
+                after the first one. 2: \(query2.primaryObserver) \
+                3: \(query3.primaryObserver)
+            """)
+            return
+        }
+        
+        #expect(ObjectIdentifier(query) == ObjectIdentifier(primaryOf2))
+        #expect(ObjectIdentifier(query) == ObjectIdentifier(primaryOf3))
+        
+        await confirmation(
+            "Confirm didChange was signaled",
+            expectedCount: 2
+        ) { confirmed in
+            let cancellable = query2.objectWillChange.sink {
+                confirmed()
+            }
+            let cancellable2 = query3.objectWillChange.sink {
+                confirmed()
+            }
+            
+            query.publishToEnclosingObserver()
+            
+            _ = cancellable
+            _ = cancellable2
+        }
+    }
+}
+
+fileprivate enum V0_0_1: VersionedSchema {
+    static let version = ModelVersion(0, 0, 1)
+    static let models: [any Vein.PersistentModel.Type] = [Test.self]
+    
+    @Model
+    final class Test: Identifiable {
+        @Field
+        var flag: Bool
+        
+        init(flag: Bool) {
+            self.flag = flag
+        }
+    }
+}
+
+fileprivate enum Migration: SchemaMigrationPlan {
+    static var schemas: [any Vein.VersionedSchema.Type] {
+        [V0_0_1.self]
+    }
+    
+    static var stages: [MigrationStage] {
+        []
+    }
+}
+#endif


### PR DESCRIPTION
resolves #95 by using a dictionary instead of closures wrapped in closures.

On deinit a observer gets removed from the primary one.

Also added test validating the new method.